### PR TITLE
Move definition into/out-of class body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,15 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz",
+      "integrity": "sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -148,6 +157,11 @@
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
       "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
       "dev": true
+    },
+    "@types/xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-3gJTS9gt27pS7U9q5IVqo4YvKSlkf2ck8ish6etuDj6LIRxkL/2Y8RMUtK/QzvE1Yv2zwWV5yemI2BS0GGGFnA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.13.0",
@@ -578,6 +592,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "core-js-pure": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
+      "integrity": "sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1705,6 +1724,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -2156,6 +2180,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xregexp": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.0.1.tgz",
+      "integrity": "sha512-flG0ykxHQLOfF886GpnY26WQkj4/RmcxYvoVcSFbg+1lPMdnXEPoTKuLzw1olKnJ+o2Wc1+RCD1oktV4bYzVlQ==",
+      "requires": {
+        "@babel/runtime-corejs3": "^7.12.1"
+      }
     },
     "y18n": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "engines": {
     "vscode": "^1.3.0"
   },
+  "dependencies": {
+    "@types/xregexp": "^4.3.0",
+    "xregexp": "^5.0.1"
+  },
   "categories": [
     "Programming Languages"
   ],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
         "title": "C-mantic: Move Definition to matching source file"
       },
       {
+        "command": "cmantic.moveDefinitionIntoOrOutOfClass",
+        "title": "C-mantic: Move Definition into/out-of class body"
+      },
+      {
         "command": "cmantic.generateGetterSetter",
         "title": "C-mantic: Generate Getter and Setter Member Functions"
       },
@@ -209,7 +213,7 @@
           "C_mantic.revealNewDefinition": {
             "type": "boolean",
             "default": true,
-            "description": "Controls whether 'Add Definition' reveals new definitions in the editor."
+            "description": "Controls whether 'Add Definition' reveals the new definition in the editor."
           }
         }
       }

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -81,13 +81,6 @@ export class CSymbol extends SourceSymbol
     async getTextForTargetPosition(
         target: SourceDocument, position: vscode.Position, declaration?: SourceSymbol
     ): Promise<string> {
-        const scopeString = declaration !== undefined
-                ? await declaration.scopeString(target, position)
-                : await this.scopeString(target, position);
-
-        const nameToEndRange = new vscode.Range(this.selectionRange.start, this.range.end);
-        const nameToEndText = this.document.getText(nameToEndRange);
-
         if (!declaration && SourceFile.isHeader(this.uri)
                 && (this.parent?.isClassOrStruct() || this.parent?.kind === vscode.SymbolKind.Namespace)) {
             const bodyRange = new vscode.Range(this.bodyStart(), this.range.end);
@@ -95,6 +88,13 @@ export class CSymbol extends SourceSymbol
             // This CSymbol is a definition, but it can be treated as a declaration for the purpose of this function.
             return await this.formatDeclarationForNewDefinition(target, position) + bodyText;
         }
+
+        const scopeString = declaration !== undefined
+                ? await declaration.scopeString(target, position)
+                : await this.scopeString(target, position);
+
+        const nameToEndRange = new vscode.Range(this.selectionRange.start, this.range.end);
+        const nameToEndText = this.document.getText(nameToEndRange);
 
         const leadingRange = new vscode.Range(this.getLeadingCommentStart(), this.scopeStringStart());
         const leadingText = this.document.getText(leadingRange);

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -445,7 +445,7 @@ export class CSymbol extends SourceSymbol
         for (const match of maskedText.matchAll(/\btemplate\s*<.+>/g)) {
             lastMatch = match;
         }
-        if (!lastMatch?.index) {
+        if (lastMatch?.index === undefined) {
             this.trueStart = this.range.start;
             return this.trueStart;
         }
@@ -461,10 +461,10 @@ export class CSymbol extends SourceSymbol
     {
         let maskedText = util.maskQuotes(this.parsableText);
         maskedText = util.maskParentheses(maskedText, true);
-        const startOffset = this.document.offsetAt(this.range.start);
+        const startOffset = this.startOffset();
         const nameEndIndex = this.document.offsetAt(this.selectionRange.end) - startOffset;
         const bodyStartIndex = maskedText.substring(nameEndIndex).match(/\s*{/)?.index;
-        if (!bodyStartIndex) {
+        if (bodyStartIndex === undefined) {
             return this.range.end;
         }
 
@@ -474,7 +474,7 @@ export class CSymbol extends SourceSymbol
 
         // Get the start of the constructor's member initializer list, if one is present.
         const initializerIndex = maskedText.substring(nameEndIndex, bodyStartIndex + nameEndIndex).match(/\s*:(?!:)/)?.index;
-        if (!initializerIndex) {
+        if (initializerIndex === undefined) {
             return this.document.positionAt(startOffset + nameEndIndex + bodyStartIndex);
         }
         return this.document.positionAt(startOffset + nameEndIndex + initializerIndex);
@@ -569,7 +569,6 @@ export class CSymbol extends SourceSymbol
 
         this.leadingCommentStart = this.getTrueStart();
         return this.leadingCommentStart;
-
     }
 
     private isChildFunctionBetween(child: CSymbol, afterOffset: number, beforeOffset: number): boolean

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -383,7 +383,7 @@ export class CSymbol extends SourceSymbol
         const leadingLines = leadingText.split(targetDoc.endOfLine);
         const alignLength = leadingLines[leadingLines.length - 1].length;
         const re_newLineAlignment = new RegExp('^' + ' '.repeat(leadingIndent + alignLength), 'gm');
-        leadingText = leadingText.replace(/\b(virtual|static|explicit|friend)\b\s*/g, '');
+        leadingText = leadingText.replace(/\b(virtual|static|explicit|friend)\s*/g, '');
         leadingText = leadingText.replace(util.getIndentationRegExp(this), '');
         let definition = this.name + '(' + parameters + ')' + declaration.substring(paramEndIndex + 1);
 
@@ -391,7 +391,7 @@ export class CSymbol extends SourceSymbol
             p_scopeString.then(scopeString => {
                 definition = definition.replace(re_newLineAlignment, ' '.repeat(alignLength + scopeString.length));
                 definition = leadingText + scopeString + definition;
-                resolve(definition.replace(/\s*\b(override|final)\b/g, ''));
+                resolve(definition.replace(/\s*(override|final)\b/g, ''));
             });
         });
     }
@@ -411,6 +411,7 @@ export class CSymbol extends SourceSymbol
         const line = this.document.lineAt(this.range.start);
         const newIndentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);
 
+        // If this CSymbol (declaration) doesn't have a comment, then we want to pull the comment from the definition.
         if (!this.hasLeadingComment()) {
             const leadingCommentRange = new vscode.Range(definition.getLeadingCommentStart(), definition.getTrueStart());
             const leadingComment = definition.document.getText(leadingCommentRange);
@@ -630,10 +631,10 @@ export class Getter implements Accessor
         this.isStatic = maskedLeadingText.match(/\bstatic\b/) !== null;
         if (maskedLeadingText.includes('<')) {
             const templateParamStart = maskedLeadingText.indexOf('<');
-            this.returnType = leadingText.substring(0, templateParamStart).replace(/\b(static|const|mutable)\b\s*/g, '')
+            this.returnType = leadingText.substring(0, templateParamStart).replace(/\b(static|const|mutable)\s*/g, '')
                     + leadingText.substring(templateParamStart);
         } else {
-            this.returnType = leadingText.replace(/\b(static|const|mutable)\b\s*/g, '');
+            this.returnType = leadingText.replace(/\b(static|const|mutable)\s*/g, '');
         }
         this.parameter = '';
         this.body = 'return ' + memberVariable.name + ';';
@@ -672,7 +673,7 @@ export class Setter implements Accessor
     {
         const setter = new Setter(memberVariable);
         const leadingText = memberVariable.leadingText();
-        const type = leadingText.replace(/\b(static|mutable)\b\s*/g, '');
+        const type = leadingText.replace(/\b(static|mutable)\s*/g, '');
         setter.isStatic = leadingText.match(/\bstatic\b/) !== null;
         setter.parameter = (!await memberVariable.isPrimitive() && !memberVariable.isPointer()
             ? 'const ' + type + '&'

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -8,6 +8,8 @@ import { SourceDocument } from './SourceDocument';
 
 const re_primitiveTypes = /\b(void|bool|char|wchar_t|char8_t|char16_t|char32_t|int|short|long|signed|unsigned|float|double)\b/g;
 const re_blockComments = /\/\*(\*(?=\/)|[^*])*\*\//g;
+// Only matches identifiers that are not folowed by a scope resolution operator (::).
+const re_scopeResolvedIdentifier = /[\w_][\w\d_]*\b(?!\s*::)/;
 
 
 /**
@@ -265,7 +267,7 @@ export class CSymbol extends SourceSymbol
 
             const startOffset = this.document.offsetAt(this.range.start);
             const type = leadingText.replace(/\b(static|const|constexpr|inline|mutable)\b/g, s => ' '.repeat(s.length));
-            const match = type.match(/[\w_][\w\d_]*\b(?!::)/);
+            const match = type.match(re_scopeResolvedIdentifier);
             if (match?.index !== undefined) {
                 return await this.resolveThisType(startOffset + match.index);
             }
@@ -280,7 +282,7 @@ export class CSymbol extends SourceSymbol
 
             const startOffset = this.document.offsetAt(this.range.start);
             const maskedText = this.parsableText.replace(/\b(typedef|const)\b/g, s => ' '.repeat(s.length));
-            const match = maskedText.match(/[\w_][\w\d_]*\b(?!::)/);
+            const match = maskedText.match(re_scopeResolvedIdentifier);
             if (match?.index !== undefined) {
                 return await this.resolveThisType(startOffset + match.index);
             }
@@ -300,7 +302,7 @@ export class CSymbol extends SourceSymbol
 
             const startOffset = this.document.offsetAt(this.range.start) + indexOfEquals + 1;
             const type = this.parsableText.substring(indexOfEquals + 1);
-            const match = type.match(/[\w_][\w\d_]*\b(?!::)/);
+            const match = type.match(re_scopeResolvedIdentifier);
             if (match?.index !== undefined) {
                 return await this.resolveThisType(startOffset + match.index);
             }

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -84,7 +84,7 @@ export class CSymbol extends SourceSymbol
         if (!declaration && SourceFile.isHeader(this.uri)
                 && (this.parent?.isClassOrStruct() || this.parent?.kind === vscode.SymbolKind.Namespace)) {
             const bodyRange = new vscode.Range(this.bodyStart(), this.range.end);
-            const bodyText = this.document.getText(bodyRange);
+            const bodyText = this.document.getText(bodyRange).replace(util.getIndentationRegExp(this), '');
             // This CSymbol is a definition, but it can be treated as a declaration for the purpose of this function.
             return await this.formatDeclarationForNewDefinition(target, position) + bodyText;
         }
@@ -384,7 +384,7 @@ export class CSymbol extends SourceSymbol
         const alignLength = leadingLines[leadingLines.length - 1].length;
         const re_newLineAlignment = new RegExp('^' + ' '.repeat(leadingIndent + alignLength), 'gm');
         leadingText = leadingText.replace(/\b(virtual|static|explicit|friend)\b\s*/g, '');
-        leadingText = leadingText.replace(/^\s+/gm, '');
+        leadingText = leadingText.replace(util.getIndentationRegExp(this), '');
         let definition = this.name + '(' + parameters + ')' + declaration.substring(paramEndIndex + 1);
 
         return new Promise(resolve => {

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -75,7 +75,7 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument
     {
         let offset: number | undefined;
         let maskedText = util.maskComments(this.getText());
-        maskedText = util.maskStringLiterals(maskedText);
+        maskedText = util.maskQuotes(maskedText);
 
         const pragmaOnceMatch = maskedText.match(/^\s*#pragma\s+once\b/);
         if (pragmaOnceMatch) {

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -173,7 +173,7 @@ export class SourceFile
             return [];
         }
 
-        let locations: vscode.Location[] = [];
+        const locations: vscode.Location[] = [];
         for (const element of input) {
             const location = (element instanceof vscode.Location) ?
                     element : new vscode.Location(element.targetUri, element.targetRange);

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -121,9 +121,11 @@ export class SourceFile
         return searchSymbolTree(this.symbols);
     }
 
-    isHeader(): boolean
+    isHeader(): boolean { return SourceFile.isHeader(this.uri); }
+
+    static isHeader(uri: vscode.Uri): boolean
     {
-        return cfg.headerExtensions().includes(util.fileExtension(this.fileName));
+        return cfg.headerExtensions().includes(util.fileExtension(uri.fsPath));
     }
 
     /**

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -161,7 +161,7 @@ export class SourceFile
         for (const symbol of this.symbols) {
             if (symbol.kind === vscode.SymbolKind.Namespace) {
                 for (const child of symbol.children) {
-                    return child.range.start.character > 0;
+                    return child.range.start.character > symbol.range.start.character;
                 }
             }
         }

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -66,6 +66,7 @@ export class SourceSymbol extends vscode.DocumentSymbol
 
     /**
      * Finds the most likely definition of this SourceSymbol and only returns a result with the same base file name.
+     * Returns undefined if the most likely definition is this SourceSymbol.
      */
     async findDefinition(): Promise<vscode.Location | undefined>
     {
@@ -80,7 +81,8 @@ export class SourceSymbol extends vscode.DocumentSymbol
             const location = (result instanceof vscode.Location) ?
                     result : new vscode.Location(result.targetUri, result.targetRange);
 
-            if (util.fileNameBase(location.uri.fsPath) === thisFileNameBase && !this.range.contains(location.range)) {
+            if (util.fileNameBase(location.uri.fsPath) === thisFileNameBase
+                    && !(location.uri.fsPath === this.uri.fsPath && this.range.contains(location.range))) {
                 return location;
             }
         }
@@ -88,6 +90,7 @@ export class SourceSymbol extends vscode.DocumentSymbol
 
     /**
      * Finds the most likely declaration of this SourceSymbol and only returns a result with the same base file name.
+     * Returns undefined if the most likely declaration is this SourceSymbol.
      */
     async findDeclaration(): Promise<vscode.Location | undefined>
     {
@@ -102,7 +105,8 @@ export class SourceSymbol extends vscode.DocumentSymbol
             const location = (result instanceof vscode.Location) ?
                     result : new vscode.Location(result.targetUri, result.targetRange);
 
-            if (util.fileNameBase(location.uri.fsPath) === thisFileNameBase && !this.range.contains(location.range)) {
+            if (util.fileNameBase(location.uri.fsPath) === thisFileNameBase
+                    && !(location.uri.fsPath === this.uri.fsPath && this.range.contains(location.range))) {
                 return location;
             }
         }

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { SourceFile } from './SourceFile';
 import * as util from './utility';
 
 
@@ -125,6 +126,19 @@ export class SourceSymbol extends vscode.DocumentSymbol
             symbol = symbol.parent;
         }
         return scopes.reverse();
+    }
+
+    async scopeString(target: SourceFile, position: vscode.Position): Promise<string>
+    {
+        let scopeString = '';
+        for (const scope of this.scopes()) {
+            const targetScope = await target.findMatchingSymbol(scope);
+            // Check if position exists inside of a namespace block. If so, omit that scope.id().
+            if (!targetScope || !targetScope.range.contains(position)) {
+                scopeString += scope.name + '::';
+            }
+        }
+        return scopeString;
     }
 
     isMemberVariable(): boolean

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -134,7 +134,7 @@ export class SourceSymbol extends vscode.DocumentSymbol
         for (const scope of this.scopes()) {
             const targetScope = await target.findMatchingSymbol(scope);
             // Check if position exists inside of a namespace block. If so, omit that scope.id().
-            if (!targetScope || !targetScope.range.contains(position)) {
+            if (!targetScope || targetScope.range.start.isBeforeOrEqual(position) || targetScope.range.end.isAfterOrEqual(position)) {
                 scopeString += scope.name + '::';
             }
         }

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -133,7 +133,7 @@ export class SourceSymbol extends vscode.DocumentSymbol
         let scopeString = '';
         for (const scope of this.scopes()) {
             const targetScope = await target.findMatchingSymbol(scope);
-            // Check if position exists inside of a namespace block. If so, omit that scope.id().
+            // Check if position exists inside of a corresponding scope block. If so, omit that scope.name.
             if (!targetScope || targetScope.range.start.isBeforeOrEqual(position) || targetScope.range.end.isAfterOrEqual(position)) {
                 scopeString += scope.name + '::';
             }

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -85,7 +85,6 @@ export async function addDefinition(
     targetUri: vscode.Uri
 ): Promise<void> {
     const shouldReveal = cfg.revealNewDefinition();
-    // Check for an existing definition. If one exists, reveal it and return.
     const existingDefinition = await functionDeclaration.findDefinition();
     if (existingDefinition) {
         if (!shouldReveal) {

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -84,9 +84,14 @@ export async function addDefinition(
     declarationDoc: SourceDocument,
     targetUri: vscode.Uri
 ): Promise<void> {
+    const shouldReveal = cfg.revealNewDefinition();
     // Check for an existing definition. If one exists, reveal it and return.
     const existingDefinition = await functionDeclaration.findDefinition();
     if (existingDefinition) {
+        if (!shouldReveal) {
+            logger.showInformationMessage(failure.definitionExists);
+            return;
+        }
         const editor = await vscode.window.showTextDocument(existingDefinition.uri);
         editor.revealRange(existingDefinition.range, vscode.TextEditorRevealType.InCenter);
         return;
@@ -100,7 +105,6 @@ export async function addDefinition(
     const functionSkeleton = await constructFunctionSkeleton(functionDeclaration, declarationDoc, targetDoc, targetPos);
 
     let editor: vscode.TextEditor | undefined;
-    const shouldReveal = cfg.revealNewDefinition();
     if (shouldReveal) {
         editor = await vscode.window.showTextDocument(targetDoc.uri);
         const revealRange = new vscode.Range(targetPos, targetPos.translate(util.lineCount(functionSkeleton)));

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -115,7 +115,11 @@ export class CodeActionProvider implements vscode.CodeActionProvider
         let declarationDoc: SourceDocument | undefined;
 
         if (definition.parent?.isClassOrStruct()) {
-            moveDefinitionIntoOrOutOfClassTitle = moveDefinitionTitle.outOfClass;
+            if (definition.parent.kind === vscode.SymbolKind.Class) {
+                moveDefinitionIntoOrOutOfClassTitle = moveDefinitionTitle.outOfClass;
+            } else {
+                moveDefinitionIntoOrOutOfClassTitle = moveDefinitionTitle.outOfStruct;
+            }
             declarationDoc = sourceDoc;
         } else {
             const declarationLocation = await definition.findDeclaration();
@@ -128,9 +132,9 @@ export class CodeActionProvider implements vscode.CodeActionProvider
                 declaration = await declarationDoc.getSymbol(declarationLocation.range.start);
 
                 if (declaration?.parent?.kind === vscode.SymbolKind.Class) {
-                    moveDefinitionIntoOrOutOfClassTitle = `Move Definition into class "${declaration.parent.name}"`;
+                    moveDefinitionIntoOrOutOfClassTitle = `${moveDefinitionTitle.intoClass} "${declaration.parent.name}"`;
                 } else if (declaration?.parent?.kind === vscode.SymbolKind.Struct) {
-                    moveDefinitionIntoOrOutOfClassTitle = `Move Definition into struct "${declaration.parent.name}"`;
+                    moveDefinitionIntoOrOutOfClassTitle = `${moveDefinitionTitle.intoStruct} "${declaration.parent.name}"`;
                 } else {
                     moveDefinitionIntoOrOutOfClassDisabled = { reason: moveDefinitionFailure.notMemberFunction };
                 }
@@ -139,7 +143,9 @@ export class CodeActionProvider implements vscode.CodeActionProvider
 
         if (sourceDoc.languageId !== 'cpp') {
             moveDefinitionIntoOrOutOfClassDisabled = { reason: moveDefinitionFailure.notCpp };
-        } else if (definition.isInline()) {
+        }
+
+        if (definition.isInline()) {
             moveDefinitionToMatchingSourceFileDisabled = { reason: moveDefinitionFailure.isInline };
         } else if (definition.isConstexpr()) {
             moveDefinitionToMatchingSourceFileDisabled = { reason: moveDefinitionFailure.isConstexpr };

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -111,11 +111,12 @@ export class CodeActionProvider implements vscode.CodeActionProvider
         let moveDefinitionIntoOrOutOfClassTitle = moveDefinitionTitle.intoOrOutOfClassPlaceholder;
         let moveDefinitionIntoOrOutOfClassDisabled: { readonly reason: string } | undefined;
 
-        let declaration: SourceSymbol | undefined;
+        let declaration: CSymbol | undefined;
         let declarationDoc: SourceDocument | undefined;
 
         if (definition.parent?.isClassOrStruct()) {
             moveDefinitionIntoOrOutOfClassTitle = moveDefinitionTitle.outOfClass;
+            declarationDoc = sourceDoc;
         } else {
             const declarationLocation = await definition.findDeclaration();
             if (declarationLocation !== undefined
@@ -164,7 +165,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider
             command: {
                 title: moveDefinitionIntoOrOutOfClassTitle,
                 command: 'cmantic.moveDefinitionIntoOrOutOfClass',
-                arguments: [definition, sourceDoc.uri]
+                arguments: [definition, declarationDoc, declaration]
             },
             disabled: moveDefinitionIntoOrOutOfClassDisabled
         }];

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -122,7 +122,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider
             if (declarationLocation !== undefined
                     && (declarationLocation?.uri.fsPath === definition.uri.fsPath
                     || declarationLocation?.uri.fsPath === matchingUri?.fsPath)) {
-                declarationDoc = declarationLocation.uri.fsPath === sourceDoc.fileName
+                declarationDoc = declarationLocation.uri.fsPath === sourceDoc.uri.fsPath
                         ? sourceDoc
                         : await SourceDocument.open(declarationLocation.uri);
                 declaration = await declarationDoc.getSymbol(declarationLocation.range.start);

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -127,8 +127,10 @@ export class CodeActionProvider implements vscode.CodeActionProvider
                         : await SourceDocument.open(declarationLocation.uri);
                 declaration = await declarationDoc.getSymbol(declarationLocation.range.start);
 
-                if (declaration?.parent?.isClassOrStruct()) {
-                    moveDefinitionIntoOrOutOfClassTitle = moveDefinitionTitle.intoClass + ' ' + declaration.parent.name;
+                if (declaration?.parent?.kind === vscode.SymbolKind.Class) {
+                    moveDefinitionIntoOrOutOfClassTitle = `Move Definition into class "${declaration.parent.name}"`;
+                } else if (declaration?.parent?.kind === vscode.SymbolKind.Struct) {
+                    moveDefinitionIntoOrOutOfClassTitle = `Move Definition into struct "${declaration.parent.name}"`;
                 } else {
                     moveDefinitionIntoOrOutOfClassDisabled = { reason: moveDefinitionFailure.notMemberFunction };
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as cfg from './configuration';
 import * as util from './utility';
 import * as path from 'path';
 import { addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile } from './addDefinition';
-import { moveDefinitionToMatchingSourceFile } from './moveDefinition';
+import { moveDefinitionToMatchingSourceFile, moveDefinitionIntoOrOutOfClass } from './moveDefinition';
 import {
     generateGetterSetter, generateGetter, generateSetter,
     generateGetterSetterFor, generateGetterFor, generateSetterFor
@@ -30,6 +30,7 @@ export function activate(context: vscode.ExtensionContext): void
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.addDefinition", addDefinition));
 
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.moveDefinitionToMatchingSourceFile", moveDefinitionToMatchingSourceFile));
+    context.subscriptions.push(vscode.commands.registerCommand("cmantic.moveDefinitionIntoOrOutOfClass", moveDefinitionIntoOrOutOfClass));
 
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.generateGetterSetter", generateGetterSetter));
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.generateGetter", generateGetter));

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -63,7 +63,9 @@ export async function moveDefinitionToMatchingSourceFile(
     }
 
     const targetDoc = await SourceDocument.open(targetUri);
-    const position = await getNewPosition(targetDoc, declaration);
+    const position = (declaration !== undefined)
+            ? await getNewPosition(targetDoc, declaration)
+            : await getNewPosition(targetDoc, definition);
 
     const workspaceEdit = new vscode.WorkspaceEdit();
     const insertText = await getInsertText(definition, position, targetDoc, declaration);

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -11,7 +11,9 @@ import { SourceFile } from './SourceFile';
 export const title = {
     matchingSourceFile: 'Move Definition to matching source file',
     outOfClass: 'Move Definition below class body',
-    intoClass: 'Move Definition into class body',
+    outOfStruct: 'Move Definition below struct body',
+    intoClass: 'Move Definition into class',
+    intoStruct: 'Move Definition into struct',
     intoOrOutOfClassPlaceholder: 'Move Definition into/out-of class body'
 };
 

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -80,50 +80,7 @@ export async function moveDefinitionToMatchingSourceFile(
     }
     return vscode.workspace.applyEdit(workspaceEdit);
 }
-// Command was called from the command-palette
-// const editor = vscode.window.activeTextEditor;
-// if (!editor) {
-//     logger.showErrorMessage(failure.noActiveTextEditor);
-//     return false;
-// }
 
-// const sourceDoc = new SourceDocument(editor.document);
-
-// const [matchingUri, symbol] = await Promise.all([
-//     getMatchingSourceFile(sourceDoc.uri),
-//     sourceDoc.getSymbol(editor.selection.start)
-// ]);
-
-// if (!symbol?.isFunctionDefinition()) {
-//     logger.showWarningMessage(failure.noFunctionDefinition);
-//     return false;
-// } else if (!matchingUri) {
-//     logger.showWarningMessage(failure.noMatchingSourceFile);
-//     return false;
-// }
-
-// definition = symbol;
-// const declarationLocation = await definition.findDeclaration();
-// if (declarationLocation) {
-//     if (declarationLocation.uri.fsPath === definition.uri.fsPath) {
-//         if (definition.document instanceof SourceDocument) {
-//             classDoc = definition.document;
-//         } else {
-//             classDoc = new SourceDocument(definition.document);
-//         }
-//     } else {
-//         classDoc = await SourceDocument.open(declarationLocation.uri);
-//     }
-//     declaration = await classDoc.getSymbol(declarationLocation.range.start);
-// } else if (definition.parent?.isClassOrStruct()) {
-//     if (definition.document instanceof SourceDocument) {
-//         classDoc = definition.document;
-//     } else {
-//         classDoc = new SourceDocument(definition.document);
-//     }
-// } else {
-//     return false;
-// }
 export async function moveDefinitionIntoOrOutOfClass(
     definition?: CSymbol,
     classDoc?: SourceDocument,

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -11,7 +11,7 @@ import { SourceFile } from './SourceFile';
 export const title = {
     matchingSourceFile: 'Move Definition to matching source file',
     outOfClass: 'Move Definition below class body',
-    intoClass: 'Move Definition into class',
+    intoClass: 'Move Definition into class body',
     intoOrOutOfClassPlaceholder: 'Move Definition into or out of class body'
 };
 
@@ -140,7 +140,7 @@ async function getInsertText(
 
 function getDeletionRange(definition: CSymbol): vscode.Range
 {
-    let deletionRange = definition.getRangeIncludingHeaderComment();
+    let deletionRange = definition.getRangeWithLeadingComment();
     if (definition.document.lineAt(deletionRange.start.line - 1).isEmptyOrWhitespace) {
         deletionRange = deletionRange.union(definition.document.lineAt(deletionRange.start.line - 1).range);
     }

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -9,8 +9,8 @@ import { SourceFile } from './SourceFile';
 
 export const title = {
     matchingSourceFile: 'Move Definition to matching source file',
-    outOfClass: 'Move Definition out of class body',
-    intoClass: 'Move Definition into class body',
+    outOfClass: 'Move Definition below class body',
+    intoClass: 'Move Definition into class',
     intoOrOutOfClassPlaceholder: 'Move Definition into or out of class body'
 };
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -99,12 +99,12 @@ export function positionAfterLastNonEmptyLine(document: vscode.TextDocument): Pr
  */
 export function getEndOfStatement(document: vscode.TextDocument, position: vscode.Position): vscode.Position
 {
-    let nextPosition = position.translate(0, 1);
-    while (document.getText(new vscode.Range(position, nextPosition)) === ';') {
-        position = nextPosition;
-        nextPosition = position.translate(0, 1);
+    const text = document.getText(new vscode.Range(position, document.lineAt(document.lineCount - 1).range.end));
+    const match = text.match(/(?<=^\s*);/);
+    if (match?.index === undefined) {
+        return position;
     }
-    return position;
+    return document.positionAt(document.offsetAt(position) + match.index + 1);
 }
 
 export function getIndentationRegExp(symbol: CSymbol): RegExp

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as xregexp from 'xregexp';
 import { ProposedPosition } from './ProposedPosition';
 import { CSymbol } from './CSymbol';
+import { logger } from './extension';
 
 /**
  * Returns the file extension without the dot.
@@ -128,6 +129,7 @@ export function masker(match: string): string { return ' '.repeat(match.length);
 
 /**
  * Performs a balanced mask of text between left and right, accounting for depth.
+ * Should only be used with single characters.
  */
 function maskBalanced(text: string, left: string, right: string, keepEnclosingChars: boolean = true): string
 {
@@ -148,12 +150,15 @@ function maskBalanced(text: string, left: string, right: string, keepEnclosingCh
         });
     } catch (error) {
         const message = error instanceof Error ? error.message : error as string;
-        const unbalancedIndexMatch = message.match(/\d+$/);
+        const unbalancedIndexMatch = message.match(/\d+/);
         if (unbalancedIndexMatch !== null) {
             // There is an unbalanced delimiter, so we mask it and try again.
             const unbalancedIndex: number = +unbalancedIndexMatch[0];
             text = text.substring(0, unbalancedIndex) + ' ' + text.substring(unbalancedIndex + 1);
             text = maskBalanced(text, left, right, keepEnclosingChars);
+        } else {
+            // This shouldn't happen, but log the error just in case.
+            logger.showErrorMessage(`Unknown parsing error: ${message}`);
         }
     } finally {
         return text;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -108,7 +108,7 @@ export function getEndOfStatement(document: vscode.TextDocument, position: vscod
 
 export function getIndentationRegExp(symbol: CSymbol): RegExp
 {
-    const line = symbol.document.lineAt(symbol.getRangeIncludingHeaderComment().start);
+    const line = symbol.document.lineAt(symbol.getRangeWithLeadingComment().start);
     const oldIndentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);
     return new RegExp('^' + oldIndentation, 'gm');
 }
@@ -149,10 +149,18 @@ export function maskStringLiterals(sourceText: string, keepEnclosingChars: boole
     return sourceText;
 }
 
-export function maskTemplateParameters(sourceText: string, keepEnclosingChars: boolean = true): string
+export function maskParameters(sourceText: string, keepEnclosingChars: boolean = true): string
 {
     if (keepEnclosingChars) {
         return sourceText.replace(/(?<=<)(>(?=>)|[^>])*(?=>)/g, masker);
     }
     return sourceText.replace(/<(>(?=>)|[^>])*>/g, masker);
+}
+
+export function maskTemplateParameters(sourceText: string, keepEnclosingChars: boolean = true): string
+{
+    if (keepEnclosingChars) {
+        return sourceText.replace(/(?<=\()(\)(?=\))|[^\)])*(?=\))/g, masker);
+    }
+    return sourceText.replace(/\((\)(?=\))|[^\)])*\)/g, masker);
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ProposedPosition } from './ProposedPosition';
+import { CSymbol } from './CSymbol';
 
 /**
  * Returns the file extension without the dot.
@@ -105,6 +106,13 @@ export function getEndOfStatement(document: vscode.TextDocument, position: vscod
     return position;
 }
 
+export function getIndentationRegExp(symbol: CSymbol): RegExp
+{
+    const line = symbol.document.lineAt(symbol.getRangeIncludingHeaderComment().start);
+    const oldIndentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);
+    return new RegExp('^' + oldIndentation, 'gm');
+}
+
 export function firstCharToUpper(str: string): string
 {
     return str.charAt(0).toUpperCase() + str.slice(1);
@@ -115,7 +123,7 @@ export function is_snake_case(label: string): boolean
     return label.match(/[\w\d]_[\w\d]/) !== null;
 }
 
-function masker(match: string): string { return ' '.repeat(match.length); }
+export function masker(match: string): string { return ' '.repeat(match.length); }
 
 export function maskComments(sourceText: string, keepEnclosingChars: boolean = true): string
 {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -111,8 +111,8 @@ export function getEndOfStatement(document: vscode.TextDocument, position: vscod
 export function getIndentationRegExp(symbol: CSymbol): RegExp
 {
     const line = symbol.document.lineAt(symbol.getTrueStart());
-    const oldIndentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);
-    return new RegExp('^' + oldIndentation, 'gm');
+    const indentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);
+    return new RegExp('^' + indentation, 'gm');
 }
 
 export function firstCharToUpper(str: string): string


### PR DESCRIPTION
Rounds-out the functionality of 'Move Definition' by adding a command/code-action to move a definition into/out-of the class body for member functions.

Additionally, this closes #6. Also, parsing has been overhauled and will now accurately find matching parentheses, brackets, etc. 'Add Definition' has also been changed to not reveal existing definitions if the user has unset the 'revealNewDefinition' setting.