### PR TITLE
Better handling of the inline specifier

### DIFF
--- a/src/Accessor.ts
+++ b/src/Accessor.ts
@@ -60,9 +60,14 @@ export class Getter implements Accessor {
 
     async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
         const eol = target.endOfLine;
-        return this.returnType + await this.memberVariable.scopeString(target, position) + this.name + '()'
-                + (this.isStatic ? '' : ' const') + curlySeparator
-                + '{' + eol + util.indentation() + this.body + eol + '}';
+        const inlineSpecifier =
+                (!this.memberVariable.parent?.range.contains(position)
+                        && this.memberVariable.document.fileName === target.fileName)
+                ? 'inline '
+                : '';
+        return inlineSpecifier + this.returnType + await this.memberVariable.scopeString(target, position)
+                + this.name + '()' + (this.isStatic ? '' : ' const') + curlySeparator + '{'
+                + eol + util.indentation() + this.body + eol + '}';
     }
 }
 
@@ -113,7 +118,13 @@ export class Setter implements Accessor {
 
     async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
         const eol = target.endOfLine;
-        return this.returnType + await this.memberVariable.scopeString(target, position) + this.name + '('
-                + this.parameter + ')' + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
+        const inlineSpecifier =
+                (!this.memberVariable.parent?.range.contains(position)
+                        && this.memberVariable.document.fileName === target.fileName)
+                ? 'inline '
+                : '';
+        return inlineSpecifier + this.returnType + await this.memberVariable.scopeString(target, position)
+                + this.name + '(' + this.parameter + ')' + curlySeparator + '{'
+                + eol + util.indentation() + this.body + eol + '}';
     }
 }

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -400,12 +400,12 @@ export class CSymbol extends SourceSymbol {
 
         // This CSymbol is a definition, but it can be treated as a declaration for the purpose of this function.
         const declaration = await this.formatDeclarationForNewDefinition(target, position, scopeString);
-        if (this.isInline() && declarationSymbol) {
-            return comment + declaration.replace(/\binline\b\s*/, '') + bodyText;
-        } else if (!declarationSymbol?.range.contains(position)
-                && declarationSymbol?.uri.fsPath === target.uri.fsPath) {
-            return comment + 'inline ' + declaration + bodyText;
-        }
+        // if (this.isInline() && declarationSymbol) {
+        //     return comment + declaration.replace(/\binline\b\s*/, '') + bodyText;
+        // } else if (!declarationSymbol?.range.contains(position)
+        //         && declarationSymbol?.uri.fsPath === target.uri.fsPath) {
+        //     return comment + 'inline ' + declaration + bodyText;
+        // }
         return comment + declaration + bodyText;
     }
 
@@ -456,14 +456,17 @@ export class CSymbol extends SourceSymbol {
         const alignLength = leadingLines[leadingLines.length - 1].length;
         const re_newLineAlignment =
                 new RegExp('^' + ' '.repeat(leadingIndent + alignLength + oldScopeString.length), 'gm');
-        leadingText = leadingText.replace(/\b(virtual|static|explicit|friend)\s*/g, '');
+        leadingText = leadingText.replace(/\b(virtual|static|explicit|friend)\b\s*/g, '');
+        if (!targetDoc.isHeader()) {
+            leadingText = leadingText.replace(/\binline\b\s*/, '');
+        }
         leadingText = leadingText.replace(util.getIndentationRegExp(this), '');
         let definition = this.name + '(' + parameters + ')' + declaration.substring(paramEndIndex + 1);
 
         definition = definition.replace(
                 re_newLineAlignment, ' '.repeat(alignLength + inlineSpecifier.length + scopeString.length));
         definition = inlineSpecifier + leadingText + scopeString + definition;
-        return definition.replace(/\s*(override|final)\b/g, '');
+        return definition.replace(/\s*\b(override|final)\b/g, '');
     }
 
     newFunctionDeclaration(): string {

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -441,7 +441,7 @@ export class CSymbol extends SourceSymbol {
         // Intelligently align the definition in the case of a multi-line declaration.
         const scopeStringStart = this.scopeStringStart();
         let leadingText = this.document.getText(new vscode.Range(this.trueStart, scopeStringStart));
-        const newInlineSpecifier =
+        const inlineSpecifier =
                 (!this.parent?.range.contains(position) && this.document.fileName === targetDoc.fileName
                         && !this.isInline() && !this.isConstexpr())
                 ? 'inline '
@@ -458,8 +458,8 @@ export class CSymbol extends SourceSymbol {
         let definition = this.name + '(' + parameters + ')' + declaration.substring(paramEndIndex + 1);
 
         definition = definition.replace(
-                re_newLineAlignment, ' '.repeat(alignLength + newInlineSpecifier.length + scopeString.length));
-        definition = newInlineSpecifier + leadingText + scopeString + definition;
+                re_newLineAlignment, ' '.repeat(alignLength + inlineSpecifier.length + scopeString.length));
+        definition = inlineSpecifier + leadingText + scopeString + definition;
         return definition.replace(/\s*(override|final)\b/g, '');
     }
 

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -115,15 +115,13 @@ export class CSymbol extends SourceSymbol {
 
         let parsableText = this.parsableText;
         this.children.forEach(child => {
-            // Mask inner classes/structs to prevent matching access specifiers within them.
-            if (child.isClassOrStruct()) {
-                const subClassOrStruct = new CSymbol(child, this.document);
-                const relativeStartOffset = subClassOrStruct.startOffset() - startOffset;
-                const relativeEndOffset = subClassOrStruct.endOffset() - startOffset;
-                parsableText = parsableText.slice(0, relativeStartOffset)
-                        + ' '.repeat(relativeEndOffset - relativeStartOffset)
-                        + parsableText.slice(relativeEndOffset);
-            }
+            // Mask children to make finding access specifiers easy.
+            const childCSymbol = new CSymbol(child, this.document);
+            const relativeStartOffset = childCSymbol.startOffset() - startOffset;
+            const relativeEndOffset = childCSymbol.endOffset() - startOffset;
+            parsableText = parsableText.slice(0, relativeStartOffset)
+                    + ' '.repeat(relativeEndOffset - relativeStartOffset)
+                    + parsableText.slice(relativeEndOffset);
         });
 
         let publicSpecifierOffset: number | undefined;
@@ -135,7 +133,7 @@ export class CSymbol extends SourceSymbol {
         }
 
         let nextAccessSpecifierOffset: number | undefined;
-        for (const match of parsableText.matchAll(/(?<!\b(class|struct)\s+)\b[\w_][\w\d_]*\s*:(?!:)/g)) {
+        for (const match of parsableText.matchAll(/\b[\w_][\w\d_]*\s*:(?!:)/g)) {
             if (match.index === undefined) {
                 continue;
             }

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -441,18 +441,25 @@ export class CSymbol extends SourceSymbol {
         // Intelligently align the definition in the case of a multi-line declaration.
         const scopeStringStart = this.scopeStringStart();
         let leadingText = this.document.getText(new vscode.Range(this.trueStart, scopeStringStart));
+        const newInlineSpecifier =
+                (!this.parent?.range.contains(position) && this.document.fileName === targetDoc.fileName
+                        && !this.isInline() && !this.isConstexpr())
+                ? 'inline '
+                : '';
         const oldScopeString = this.document.getText(new vscode.Range(scopeStringStart, this.selectionRange.start));
         const line = this.document.lineAt(this.range.start);
         const leadingIndent = line.text.substring(0, line.firstNonWhitespaceCharacterIndex).length;
         const leadingLines = leadingText.split(targetDoc.endOfLine);
         const alignLength = leadingLines[leadingLines.length - 1].length;
-        const re_newLineAlignment = new RegExp('^' + ' '.repeat(leadingIndent + alignLength + oldScopeString.length), 'gm');
+        const re_newLineAlignment =
+                new RegExp('^' + ' '.repeat(leadingIndent + alignLength + oldScopeString.length), 'gm');
         leadingText = leadingText.replace(/\b(virtual|static|explicit|friend)\s*/g, '');
         leadingText = leadingText.replace(util.getIndentationRegExp(this), '');
         let definition = this.name + '(' + parameters + ')' + declaration.substring(paramEndIndex + 1);
 
-        definition = definition.replace(re_newLineAlignment, ' '.repeat(alignLength + scopeString.length));
-        definition = leadingText + scopeString + definition;
+        definition = definition.replace(
+                re_newLineAlignment, ' '.repeat(alignLength + newInlineSpecifier.length + scopeString.length));
+        definition = newInlineSpecifier + leadingText + scopeString + definition;
         return definition.replace(/\s*(override|final)\b/g, '');
     }
 

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -39,8 +39,13 @@ export class OpEqual implements Operator {
 
     async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
         const eol = target.endOfLine;
-        return this.returnType + await this.parent.scopeString(target, position) + this.name + '(' + this.parameter
-                + ') const' + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
+        const inlineSpecifier =
+                (!this.parent?.range.contains(position)
+                        && this.parent.document.fileName === target.fileName)
+                ? 'inline '
+                : '';
+        return inlineSpecifier + this.returnType + await this.parent.scopeString(target, position) + this.name + '('
+                + this.parameter + ') const' + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
     }
 
     setMemberVariables(memberVariables: SourceSymbol[]): void {
@@ -87,7 +92,12 @@ export class OpNotEqual implements Operator {
 
     async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
         const eol = target.endOfLine;
-        return this.returnType + await this.parent.scopeString(target, position) + this.name + '(' + this.parameter
-                + ') const' + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
+        const inlineSpecifier =
+                (!this.parent?.range.contains(position)
+                        && this.parent.document.fileName === target.fileName)
+                ? 'inline '
+                : '';
+        return inlineSpecifier + this.returnType + await this.parent.scopeString(target, position) + this.name + '('
+                + this.parameter + ') const' + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
     }
 }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -139,7 +139,7 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
         // Get the first 5 symbols that come before and after declaration.
         // We look for definitions of these symbols in targetDoc and return a position relative to the closest one.
         const siblingFunctions = (declaration.parent ? declaration.parent.children : this.symbols).filter(symbol => {
-            return symbol.isFunction();
+            return new CSymbol(symbol, this).isFunctionDeclaration();
         });
         const declarationSelectionRange = declaration.selectionRange;
         const declarationIndex = siblingFunctions.findIndex(symbol => {

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -173,7 +173,8 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
                 }
 
                 const definition = await targetDoc.getSymbol(definitionLocation.range.start);
-                if (definition) {
+                if (definition && !(declaration.uri.fsPath === definition.uri.fsPath
+                        && declaration.parent?.range.contains(definition.selectionRange))) {
                     return new ProposedPosition(definition.range.end, {
                         relativeTo: definition.range,
                         after: true
@@ -195,7 +196,8 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
                 }
 
                 const definition = await targetDoc.getSymbol(definitionLocation.range.start);
-                if (definition) {
+                if (definition && !(declaration.uri.fsPath === definition.uri.fsPath
+                        && declaration.parent?.range.contains(definition.selectionRange))) {
                     const leadingCommentStart = definition.leadingCommentStart;
                     return new ProposedPosition(leadingCommentStart, {
                         relativeTo: new vscode.Range(leadingCommentStart, definition.range.end),

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -265,7 +265,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             moveDefinitionIntoOrOutOfClass.disable(moveDefinitionFailure.notCpp);
         }
 
-        if (definition.isInline()) {
+        if (definition.isInline() && !declaration) {
             moveDefinitionToMatchingSourceFile.disable(moveDefinitionFailure.isInline);
         } else if (definition.isConstexpr()) {
             moveDefinitionToMatchingSourceFile.disable(moveDefinitionFailure.isConstexpr);

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -265,7 +265,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             moveDefinitionIntoOrOutOfClass.disable(moveDefinitionFailure.notCpp);
         }
 
-        if (definition.isInline() && !declaration) {
+        if (definition.isInline() && (!declaration || declaration.isInline())) {
             moveDefinitionToMatchingSourceFile.disable(moveDefinitionFailure.isInline);
         } else if (definition.isConstexpr()) {
             moveDefinitionToMatchingSourceFile.disable(moveDefinitionFailure.isConstexpr);


### PR DESCRIPTION
C-mantic will now handle the `inline` specifier better. When creating definitions for functions within the a header file, `inline` will be added to them to prevent ODR violations. Additionally, `inline` function definitions can now be moved to a source file, given that there is a declaration in the header file, and the `inline` specifier will be removed. When moving a definition to a header file, `inline` will be added.