### PR TITLE
Add Declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to the `C-mantic` extension will be documented in this file.
 
+## [Unreleased]
+### Added
+- Added `cmantic.addDeclaration` command/code-action. `Add Declaration` will add a declaration of a function to the cooresponding header file if the function is not already declared there. If the function is a member function, the declaration will be added to the class, wherever it is defined. Additionally for member functions, `Add Declaration` will be provided as a `Quick Fix` (suggested in the blue light-bulb menu), because defining a member function outisde of the class with no declaration is an error. (#21)
+
+### Changed
+- `Move Definition into class` will now be available for member functions that are not declared in the class. Similar to `Add Declaration`, this code-action will be provided as a `Quick Fix`, since it also fixes the underlying error. (#21)
+- Changed the way that code generation determines line-spacing: If code is being inserted between 2 non-empty lines, it will no longer place an empty line in-between.
+
 ## [0.5.2] - February 28, 2021
 ### Added
 - Template support has been expanded to properly generate member functions of class templates. Template parameter packs and default template arguments are now handled properly. (#18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the `C-mantic` extension will be documented in this file.
 ## [Unreleased]
 ### Added
 - Added `cmantic.addDeclaration` command/code-action. `Add Declaration` will add a declaration of a function to the cooresponding header file if the function is not already declared there. If the function is a member function, the declaration will be added to the class, wherever it is defined. Additionally for member functions, `Add Declaration` will be provided as a `Quick Fix` (suggested in the blue light-bulb menu), because defining a member function outisde of the class with no declaration is an error. (#21)
+- Added a setting `Code Actions: Enable Add Declaration` to control whether the `Add Declaration` code-action is suggested (light-bulb menu). (#21)
 
 ### Changed
 - `Move Definition into class` will now be available for member functions that are not declared in the class. Similar to `Add Declaration`, this code-action will be provided as a `Quick Fix`, since it also fixes the underlying error. (#21)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
         "title": "C-mantic: Add Definition in this file"
       },
       {
+        "command": "cmantic.addDeclaration",
+        "title": "C-mantic: Add Declaration"
+      },
+      {
         "command": "cmantic.moveDefinitionToMatchingSourceFile",
         "title": "C-mantic: Move Definition to matching source file"
       },

--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
             "default": true,
             "description": "Controls whether the 'Add Definition' code actions are suggested (light-bulb menu). This does not prevent the corresponding commands from being used."
           },
+          "C_mantic.codeActions.enableAddDeclaration": {
+            "type": "boolean",
+            "default": true,
+            "description": "Controls whether the 'Add Declaration' code action is suggested (light-bulb menu). This does not prevent the command from being used."
+          },
           "C_mantic.codeActions.enableMoveDefinition": {
             "type": "boolean",
             "default": true,

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -18,13 +18,13 @@ const re_beginingOfScopeString = /(?<!::\s*|[\w\d_])[\w_][\w\d_]*(?=\s*::)/g;
  * Extends SourceSymbol by adding a document property that gives more semantic-awareness over SourceSymbol.
  */
 export class CSymbol extends SourceSymbol {
-    readonly document: vscode.TextDocument;
+    readonly document: SourceDocument;
     parent?: CSymbol;
 
     /**
      * When constructing with a SourceSymbol that has a parent, the parent parameter may be omitted.
      */
-    constructor(symbol: SourceSymbol, document: vscode.TextDocument) {
+    constructor(symbol: SourceSymbol, document: SourceDocument) {
         super(symbol, document.uri);
         this.document = document;
 

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -239,6 +239,22 @@ export class CSymbol extends SourceSymbol {
         return new SubSymbol(this.document, new vscode.Range(start, end));
     }
 
+    async getParentClass(): Promise<CSymbol | undefined> {
+        const immediateScope = this.immediateScope();
+        if (immediateScope) {
+            const immediateScopeDefinition = await immediateScope.findDefinition();
+            if (immediateScopeDefinition) {
+                const immediateScopeDoc = (immediateScopeDefinition.uri.fsPath === this.uri.fsPath)
+                        ? this.document
+                        : await SourceDocument.open(immediateScopeDefinition.uri);
+                const immediateScopeSymbol = await immediateScopeDoc.getSymbol(immediateScopeDefinition.range.start);
+                if (immediateScopeSymbol?.isClassOrStruct()) {
+                    return immediateScopeSymbol;
+                }
+            }
+        }
+    }
+
     baseClasses(): SubSymbol[] {
         if (!this.isClassOrStruct()) {
             return [];

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -96,6 +96,8 @@ export class CSymbol extends SourceSymbol {
 
     endOffset(): number { return this.document.offsetAt(this.range.end); }
 
+    trueStartOffset(): number { return this.document.offsetAt(this.trueStart); }
+
     isBefore(offset: number): boolean { return this.endOffset() < offset; }
 
     isAfter(offset: number): boolean { return this.startOffset() > offset; }
@@ -222,6 +224,19 @@ export class CSymbol extends SourceSymbol {
         }
 
         return scopeString;
+    }
+
+    immediateScope(): SubSymbol | undefined {
+        const match = this.parsableLeadingText.match(/[\w_][\w\d_]*(?=\s*::\s*$)/);
+        if (!match || match.index === undefined) {
+            return;
+        }
+
+        const startOffset = this.startOffset() + match.index;
+        const start = this.document.positionAt(startOffset);
+        const end = this.document.positionAt(startOffset + match[0].length);
+
+        return new SubSymbol(this.document, new vscode.Range(start, end));
     }
 
     baseClasses(): SubSymbol[] {
@@ -456,12 +471,12 @@ export class CSymbol extends SourceSymbol {
         return false;
     }
 
-    async getTextForTargetPosition(
-        target: SourceDocument, position: vscode.Position, declarationSymbol?: CSymbol
+    async getDefinitionForTargetPosition(
+        targetDoc: SourceDocument, position: vscode.Position, declarationSymbol?: CSymbol
     ): Promise<string> {
         const bodyRange = new vscode.Range(this.declarationEnd(), this.range.end);
         const bodyText = this.document.getText(bodyRange).replace(parse.getIndentationRegExp(this), '');
-        const scopeString = await declarationSymbol?.scopeString(target, position);
+        const scopeString = await declarationSymbol?.scopeString(targetDoc, position);
 
         let comment = '';
         if (cfg.alwaysMoveComments()) {
@@ -470,8 +485,12 @@ export class CSymbol extends SourceSymbol {
         }
 
         // This CSymbol is a definition, but it can be treated as a declaration for the purpose of this function.
-        const declaration = await this.formatDeclarationForNewDefinition(target, position, scopeString);
+        const declaration = await this.formatDeclaration(targetDoc, position, scopeString);
         return comment + declaration + bodyText;
+    }
+
+    async getDeclarationForTargetPosition(targetDoc: SourceDocument, position: vscode.Position): Promise<string> {
+        return await this.formatDeclaration(targetDoc, position) + ';';
     }
 
     /**
@@ -481,10 +500,10 @@ export class CSymbol extends SourceSymbol {
         if (!this.isFunctionDeclaration()) {
             return '';
         }
-        return this.formatDeclarationForNewDefinition(targetDoc, position);
+        return this.formatDeclaration(targetDoc, position);
     }
 
-    private async formatDeclarationForNewDefinition(
+    private async formatDeclaration(
         targetDoc: SourceDocument, position: vscode.Position, scopeString?: string
     ): Promise<string> {
         if (scopeString === undefined) {
@@ -500,7 +519,7 @@ export class CSymbol extends SourceSymbol {
 
         const nameEndIndex = this.document.offsetAt(this.selectionRange.end) - this.document.offsetAt(this.trueStart);
         const paramStartIndex = maskedDeclaration.indexOf('(', nameEndIndex);
-        const paramEndIndex = maskedDeclaration.indexOf(')');
+        const paramEndIndex = maskedDeclaration.indexOf(')', nameEndIndex);
         if (paramStartIndex === -1 || paramEndIndex === -1) {
             return '';
         }
@@ -512,7 +531,7 @@ export class CSymbol extends SourceSymbol {
         const inlineSpecifier =
                 ((!this.parent || !util.containsExclusive(this.parent.range, position))
                         && (this.document.fileName === targetDoc.fileName || targetDoc.isHeader())
-                        && !this.isInline() && !this.isConstexpr())
+                        && !this.isInline() && !this.isConstexpr() && this.isFunctionDeclaration())
                 ? 'inline '
                 : '';
 
@@ -601,7 +620,7 @@ export class CSymbol extends SourceSymbol {
         const maskedText = parse.maskParentheses(this.parsableText);
         const startOffset = this.startOffset();
         const nameEndIndex = this.document.offsetAt(this.selectionRange.end) - startOffset;
-        const bodyStartIndex = maskedText.substring(nameEndIndex).search(/\s*{/);
+        const bodyStartIndex = maskedText.substring(nameEndIndex).search(/\s*{|\s*;$/);
         if (bodyStartIndex === -1) {
             return this.range.end;
         }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -144,9 +144,7 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
 
         // Get the first 5 symbols that come before and after declaration.
         // We look for definitions of these symbols in targetDoc and return a position relative to the closest one.
-        const siblingFunctions = (declaration.parent ? declaration.parent.children : this.symbols).filter(symbol => {
-            return symbol.isFunction();
-        });
+        const siblingFunctions = SourceDocument.siblingFunctions(declaration, this.symbols);
         const declarationSelectionRange = declaration.selectionRange;
         const declarationIndex = siblingFunctions.findIndex(symbol => {
             return symbol.selectionRange.isEqual(declarationSelectionRange);
@@ -336,5 +334,11 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
 
     private getEndOfStatement(position: vscode.Position): vscode.Position {
         return parse.getEndOfStatement(this, position);
+    }
+
+    private static siblingFunctions(symbol: SourceSymbol, topLevelSymbols: SourceSymbol[]): SourceSymbol[] {
+        return (symbol.parent ? symbol.parent.children : topLevelSymbols).filter(sibling => {
+            return sibling.isFunction();
+        });
     }
 }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -145,10 +145,7 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
         // Get the first 5 symbols that come before and after declaration.
         // We look for definitions of these symbols in targetDoc and return a position relative to the closest one.
         const siblingFunctions = SourceDocument.siblingFunctions(declaration, this.symbols);
-        const declarationSelectionRange = declaration.selectionRange;
-        const declarationIndex = siblingFunctions.findIndex(symbol => {
-            return symbol.selectionRange.isEqual(declarationSelectionRange);
-        });
+        const declarationIndex = SourceDocument.indexOfSymbol(declaration, siblingFunctions);
         const before = siblingFunctions.slice(0, declarationIndex).reverse();
         const after = siblingFunctions.slice(declarationIndex + 1);
         if (declarationOrPosition instanceof ProposedPosition) {
@@ -339,6 +336,13 @@ export class SourceDocument extends SourceFile implements vscode.TextDocument {
     private static siblingFunctions(symbol: SourceSymbol, topLevelSymbols: SourceSymbol[]): SourceSymbol[] {
         return (symbol.parent ? symbol.parent.children : topLevelSymbols).filter(sibling => {
             return sibling.isFunction();
+        });
+    }
+
+    private static indexOfSymbol(symbol: SourceSymbol, siblings: SourceSymbol[]): number {
+        const declarationSelectionRange = symbol.selectionRange;
+        return siblings.findIndex(sibling => {
+            return sibling.selectionRange.isEqual(declarationSelectionRange);
         });
     }
 }

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -51,7 +51,7 @@ export class SourceFile {
             this.symbols = await this.executeSourceSymbolProvider();
         }
 
-        function searchSymbolTree(sourceSymbols: SourceSymbol[]): SourceSymbol | undefined {
+        return function searchSymbolTree(sourceSymbols: SourceSymbol[]): SourceSymbol | undefined {
             for (const sourceSymbol of sourceSymbols) {
                 if (!sourceSymbol.range.contains(position)) {
                     continue;
@@ -64,9 +64,7 @@ export class SourceFile {
                     return child ? child : sourceSymbol;
                 }
             }
-        }
-
-        return searchSymbolTree(this.symbols);
+        } (this.symbols);
     }
 
     static async getSymbol(location: vscode.Location): Promise<SourceSymbol | undefined> {
@@ -93,7 +91,7 @@ export class SourceFile {
             this.symbols = await this.executeSourceSymbolProvider();
         }
 
-        function searchSymbolTree(sourceSymbols: SourceSymbol[]): SourceSymbol | undefined {
+        return function searchSymbolTree(sourceSymbols: SourceSymbol[]): SourceSymbol | undefined {
             for (const sourceSymbol of sourceSymbols) {
                 if (sourceSymbol.equals(target)) {
                     return sourceSymbol;
@@ -104,9 +102,7 @@ export class SourceFile {
                     return foundSymbol;
                 }
             }
-        };
-
-        return searchSymbolTree(this.symbols);
+        } (this.symbols);
     }
 
     isHeader(): boolean { return SourceFile.isHeader(this.uri); }
@@ -123,19 +119,19 @@ export class SourceFile {
             this.symbols = await this.executeSourceSymbolProvider();
         }
 
-        const searchSymbolTree = (sourceSymbols: SourceSymbol[]): SourceSymbol[] => {
+        const uri = this.uri;
+
+        return function searchSymbolTree(sourceSymbols: SourceSymbol[]): SourceSymbol[] {
             const namespaces: SourceSymbol[] = [];
             for (const sourceSymbol of sourceSymbols) {
                 if (sourceSymbol.kind === vscode.SymbolKind.Namespace) {
-                    const namespace = new SourceSymbol(sourceSymbol, this.uri, sourceSymbol.parent);
+                    const namespace = new SourceSymbol(sourceSymbol, uri, sourceSymbol.parent);
                     namespace.children = searchSymbolTree(sourceSymbol.children);
                     namespaces.push(namespace);
                 }
             }
             return namespaces;
-        };
-
-        return searchSymbolTree(this.symbols);
+        } (this.symbols);
     }
 
     async isNamespaceBodyIndented(): Promise<boolean> {

--- a/src/addDeclaration.ts
+++ b/src/addDeclaration.ts
@@ -1,0 +1,46 @@
+import * as vscode from 'vscode';
+import { logger } from './logger';
+import { SourceDocument } from './SourceDocument';
+import { CSymbol } from './CSymbol';
+
+
+export const title = {
+    currentFile: 'Add Declaration in this file',
+    matchingHeaderFile: 'Add Declaration in matching header file'
+};
+
+export const failure = {
+    noActiveTextEditor: 'No active text editor detected.',
+    notSourceFile: 'This file is not a source file.',
+    noFunctionDefinition: 'No function definition detected.',
+    noMatchingHeaderFile: 'No matching header file was found.',
+    declarationExists: 'A declaration for this function already exists.'
+};
+
+export async function addDeclaration(
+    functionDefinition: CSymbol,
+    definitionDoc: SourceDocument,
+    targetUri: vscode.Uri
+): Promise<void> {
+    // Find the position for the new function definition.
+    const targetDoc = (targetUri.fsPath === definitionDoc.uri.fsPath)
+            ? definitionDoc
+            : await SourceDocument.open(targetUri);
+
+    const existingDeclaration = await functionDefinition.findDeclaration();
+    if (existingDeclaration?.uri.fsPath === targetDoc.uri.fsPath) {
+        const existingDeclarationSymbol = await targetDoc.getSymbol(existingDeclaration.range.start);
+        if (existingDeclarationSymbol?.equals(functionDefinition)) {
+            logger.alertInformation(failure.declarationExists);
+            return;
+        }
+    }
+
+    const targetPos = await definitionDoc.findPositionForFunctionDeclaration(functionDefinition, targetDoc);
+    const declaration = await functionDefinition.getDeclarationForTargetPosition(targetDoc, targetPos);
+    const formattedDeclaration = targetPos.formatTextToInsert(declaration, targetDoc);
+
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    workspaceEdit.insert(targetDoc.uri, targetPos, formattedDeclaration);
+    await vscode.workspace.applyEdit(workspaceEdit);
+}

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as cfg from './configuration';
+import * as util from './utility';
 import { SourceDocument } from './SourceDocument';
 import { CSymbol } from './CSymbol';
 import { failure as addDefinitionFailure, title as addDefinitionTitle } from './addDefinition';
@@ -223,7 +224,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         if (!sourceDoc.isHeader()) {
             addDefinitionInMatchingSourceFile.disable(addDefinitionFailure.notHeaderFile);
         } else if (matchingUri) {
-            const displayPath = this.formatPathToDisplay(matchingUri);
+            const displayPath = util.formatPathToDisplay(matchingUri);
             if (declaration.isConstructor()) {
                 addDefinitionInMatchingSourceFile.setTitle(`Generate Constructor in "${displayPath}"`);
             } else {
@@ -250,7 +251,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         if (sourceDoc.isHeader()) {
             addDeclaration.disable(addDeclarationFailure.notSourceFile);
         } else if (matchingUri) {
-            const displayPath = this.formatPathToDisplay(matchingUri);
+            const displayPath = util.formatPathToDisplay(matchingUri);
             addDeclaration.setTitle(`Add Declaration in "${displayPath}"`);
         }
 
@@ -360,7 +361,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         }
 
         if (matchingUri) {
-            const displayPath = this.formatPathToDisplay(matchingUri);
+            const displayPath = util.formatPathToDisplay(matchingUri);
             moveDefinitionToMatchingSourceFile.setTitle(`Move Definition to "${displayPath}"`);
         } else {
             moveDefinitionToMatchingSourceFile.disable(moveDefinitionFailure.noMatchingSourceFile);
@@ -441,14 +442,5 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         }
 
         return [addHeaderGuard, addInclude, createMatchingSourceFile];
-    }
-
-    private formatPathToDisplay(uri: vscode.Uri): string {
-        const relativePath = vscode.workspace.asRelativePath(uri);
-        // Arbitrary limit, as to not display a path that's running all the way across the screen.
-        if (relativePath.length > 60) {
-            return relativePath.slice(0, 28) + '....' + relativePath.slice(-28);
-        }
-        return relativePath;
     }
 }

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -62,6 +62,7 @@ export class SourceAction extends CodeAction {
 
 export class CodeActionProvider implements vscode.CodeActionProvider {
     private addDefinitionEnabled: boolean = cfg.enableAddDefinition();
+    private addDeclarationEnabled: boolean = cfg.enableAddDeclaration();
     private moveDefinitionEnabled: boolean = cfg.enableMoveDefinition();
     private generateGetterSetterEnabled: boolean = cfg.enableGenerateGetterSetter();
 
@@ -69,6 +70,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         pushDisposable(vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
             if (event.affectsConfiguration(cfg.baseConfigurationString)) {
                 this.addDefinitionEnabled = cfg.enableAddDefinition();
+                this.addDeclarationEnabled = cfg.enableAddDeclaration();
                 this.moveDefinitionEnabled = cfg.enableMoveDefinition();
                 this.generateGetterSetterEnabled = cfg.enableGenerateGetterSetter();
             }
@@ -154,7 +156,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         rangeOrSelection: vscode.Range | vscode.Selection
     ): boolean {
         return symbol.isFunctionDefinition()
-            && (symbol.selectionRange.contains(rangeOrSelection.start)
+            && (this.addDeclarationEnabled && symbol.selectionRange.contains(rangeOrSelection.start)
                 || context.only?.contains(vscode.CodeActionKind.Refactor) === true);
     }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -203,6 +203,10 @@ export function enableAddDefinition(): boolean {
     return configuration().get<boolean>('codeActions.enableAddDefinition', defaultEnableCodeAction);
 }
 
+export function enableAddDeclaration(): boolean {
+    return configuration().get<boolean>('codeActions.enableAddDeclaration', defaultEnableCodeAction);
+}
+
 export function enableMoveDefinition(): boolean {
     return configuration().get<boolean>('codeActions.enableMoveDefinition', defaultEnableCodeAction);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.languages.registerCodeActionsProvider(
             [{ scheme: 'file', language: 'c' }, { scheme: 'file', language: 'cpp' }],
             new CodeActionProvider(),
-            { providedCodeActionKinds: [vscode.CodeActionKind.Refactor, vscode.CodeActionKind.Source] });
+            { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix, vscode.CodeActionKind.Refactor, vscode.CodeActionKind.Source] });
 
     pushDisposable(vscode.workspace.onDidOpenTextDocument(onDidOpenTextDocument));
     pushDisposable(vscode.workspace.onDidCreateFiles(onDidCreateFiles));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as util from './utility';
 import * as path from 'path';
 import * as fs from 'fs';
 import { addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile } from './addDefinition';
+import { addDeclaration } from './addDeclaration';
 import { moveDefinitionToMatchingSourceFile, moveDefinitionIntoOrOutOfClass } from './moveDefinition';
 import {
     generateGetterSetter, generateGetter, generateSetter,
@@ -27,6 +28,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.addDefinitionInSourceFile", addDefinitionInSourceFile));
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.addDefinitionInCurrentFile", addDefinitionInCurrentFile));
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.addDefinition", addDefinition));
+
+    context.subscriptions.push(vscode.commands.registerCommand("cmantic.addDeclaration", addDeclaration));
 
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.moveDefinitionToMatchingSourceFile", moveDefinitionToMatchingSourceFile));
     context.subscriptions.push(vscode.commands.registerCommand("cmantic.moveDefinitionIntoOrOutOfClass", moveDefinitionIntoOrOutOfClass));

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -158,6 +158,20 @@ export async function moveDefinitionIntoOrOutOfClass(
         const deletionRange = getDeletionRange(definition);
         workspaceEdit.delete(definition.uri, deletionRange);
         return vscode.workspace.applyEdit(workspaceEdit);
+    } else {
+        const parentClass = await definition.getParentClass();
+        if (parentClass) {
+            const position = await definition.document.findPositionForFunctionDeclaration(definition, parentClass.document);
+
+            let insertText = await definition.getDefinitionForTargetPosition(classDoc, position);
+            insertText = position.formatTextToInsert(insertText, classDoc);
+
+            const workspaceEdit = new vscode.WorkspaceEdit();
+            workspaceEdit.insert(classDoc.uri, position, insertText);
+            const deletionRange = getDeletionRange(definition);
+            workspaceEdit.delete(definition.uri, deletionRange);
+            return vscode.workspace.applyEdit(workspaceEdit);
+        }
     }
 
     logger.alertWarning(failure.noFunctionDeclaration);

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -72,7 +72,7 @@ export async function moveDefinitionToMatchingSourceFile(
             ? await getNewPosition(targetDoc, declaration)
             : await getNewPosition(targetDoc, definition);
 
-    let insertText = await definition.getTextForTargetPosition(targetDoc, position, declaration);
+    let insertText = await definition.getDefinitionForTargetPosition(targetDoc, position, declaration);
     insertText = position.formatTextToInsert(insertText, targetDoc);
 
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -139,7 +139,7 @@ export async function moveDefinitionIntoOrOutOfClass(
     if (definition.parent?.isClassOrStruct()) {
         const position = await getNewPosition(classDoc, definition);
 
-        let insertText = await definition.getTextForTargetPosition(classDoc, position, declaration);
+        let insertText = await definition.getDefinitionForTargetPosition(classDoc, position, declaration);
         insertText = position.formatTextToInsert(insertText, classDoc);
 
         const workspaceEdit = new vscode.WorkspaceEdit();

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -127,9 +127,12 @@ export async function moveDefinitionIntoOrOutOfClass(
                         ? sourceDoc
                         : await SourceDocument.open(declarationLocation.uri);
                 declaration = await classDoc.getSymbol(declarationLocation.range.start);
+                if (!declaration?.parent?.isClassOrStruct()) {
+                    declaration = undefined;
+                }
             }
 
-            if (!declaration?.parent?.isClassOrStruct() || !classDoc) {
+            if (declaration?.parent?.isClassOrStruct() === false || !classDoc) {
                 logger.alertWarning(failure.notMemberFunction);
                 return false;
             }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -172,3 +172,12 @@ export function makeCamelCase(text: string): string {
 export function MakePascalCase(text: string): string {
     return firstCharToUpper(text.replace(/_[a-z]/g, match => match.charAt(1).toUpperCase()).replace('_', ''));
 }
+
+export function formatPathToDisplay(uri: vscode.Uri): string {
+    const relativePath = vscode.workspace.asRelativePath(uri);
+    // Arbitrary limit, as to not display a path that's running all the way across the screen.
+    if (relativePath.length > 60) {
+        return relativePath.slice(0, 28) + '....' + relativePath.slice(-28);
+    }
+    return relativePath;
+}


### PR DESCRIPTION
Adds a command/code-action to add a declaration for a function that is not declared. The declaration will be added to the header file, or wherever the class is defined if it is a member function. If the function is a member function, the code-action will be provided as a 'Quick Fix' (suggested in the blue light-bulb menu), because it is an error to define a member function that is not declared in the class body (which the language server should complain about). Additionally, 'Move Definition into class' will be provided as a quick-fix for this scenario, since that would also fix the error (previously, 'Move Definition into class' could not be used if the function was not already declared in the class).