### PR TITLE
Add multiple definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to the `C-mantic` extension will be documented in this file.
 - Removed the setting `C_mantic.cpp.indentation.namespace`. Namespace indentation will always be auto-detected now.
 
 ### Fixed
-- Fixed a bug when determining if a cached matching header/source file still exists. This would cause some commands to throw an error.
+- Fixed a bug when determining if a cached matching header/source file still exists. This would cause some commands to throw an error if the file has been removed.
+- Fixed a bug where name qualification of generated code would contain duplicate namespace names.
 
 ## [0.6.3] - March 31, 2021
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the `C-mantic` extension will be documented in this file.
 ## [Unreleased]
 ### Added
 - Added `cmantic.generateStreamOutputOperator` command/code-action. Works very similar to `cmantic.generateEqualityOperators`.
+- Added `cmantic.addDefinitions` command/code-action, accessible through the `Refactor...` menu.
 
 ### Changed
 - Removed the setting `C_mantic.cpp.indentation.namespace`. Namespace indentation will always be auto-detected now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the `C-mantic` extension will be documented in this file.
 ### Added
 - Added `cmantic.generateStreamOutputOperator` command/code-action. Works very similar to `cmantic.generateEqualityOperators`.
 
+### Changed
+- Removed the setting `C_mantic.cpp.indentation.namespace`. Namespace indentation will always be auto-detected now.
+
 ### Fixed
 - Fixed a bug when determining if a cached matching header/source file still exists. This would cause some commands to throw an error.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The `Add Definition in this file` command generates an empty definition for a fu
 
 `Add Definition` will look for definitions of neighboring declarations in the target file and try to place new definitions next to them. If a neighboring definition cannot be found then the new definition will be placed at the end of the file. Additionally, `Add Definition` will respect the formatting of your code and will intelligently adapt the whitespace allignment in the case of multi-line declarations. The placement of the opening curly brace can be controlled with the setting `Curly Brace Format: Function` for C and C++, each. By default, the new definition will be revealed in the editor when added. This can be disabled with `Reveal New Definition` in the settings.
 
+You may also generate many definitions at a time by selecting `Add Definitions...` in the `Refactor...` menu. This command will find all undefined function in the file and prompt you to select which ones to add definitions for. After selecting functions you will be prompted to select which file to add the definitions to (either the same file, or the matching source file). If a matching source file doesn't already exist, you can select to create one (this invokes [Create Matching Source File](#create-matching-source-file)).
+
 #### **Generate Constructor**
 
 `Generate Constructor` extends `Add Definition` by prompting you to select what you want to initialize in the constructor (delegating constructor, base class constructor(s), member variables) and will generate the boiler-plate for the initializer list.
@@ -97,6 +99,8 @@ Additionally, if the file does not already include `ostream` or `iostream` direc
 The `Create Matching Source File` command creates a new source file from a header by prompting you for a target directory and file extension. Target directories containing source files will be recommended based on their similarity the header file's directory. Additionally, C-mantic will automatically pick a file extension if all source files in the target directory have the same extension. An include statement for the header file will be inserted into the new source file.
 
 When creating a C++ source file from a header containing namespaces, these namespace blocks will be generated too. Check out the settings for various ways to customize this behavior, or to disable namespace generation.
+
+After the file is created, you will also be asked if you want to add definitions for functions declared in the header file.
 
 ### **Add Header Guard**
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
         "title": "C-mantic: Add Definition in this file"
       },
       {
+        "command": "cmantic.addDefinitions",
+        "title": "C-mantic: Add Definitions..."
+      },
+      {
         "command": "cmantic.addDeclaration",
         "title": "C-mantic: Add Declaration"
       },

--- a/package.json
+++ b/package.json
@@ -216,16 +216,6 @@
             "default": "Auto",
             "description": "Controls how to format the opening curly brace when generating namespaces from a header in C++. 'Auto' will detect namespace curly brace format from the header file."
           },
-          "C_mantic.cpp.indentation.namespace": {
-            "type": "string",
-            "enum": [
-              "Auto",
-              "Always",
-              "Never"
-            ],
-            "default": "Auto",
-            "description": "Controls whether to indent the body when generating namespaces from a header in C++. 'Auto' will detect namespace indentation from the header file."
-          },
           "C_mantic.cpp.generateNamespaces": {
             "type": "boolean",
             "default": true,

--- a/package.json
+++ b/package.json
@@ -43,63 +43,78 @@
     "commands": [
       {
         "command": "cmantic.addDefinitionInSourceFile",
-        "title": "C-mantic: Add Definition in matching source file"
+        "title": "Add Definition in matching source file",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.addDefinitionInCurrentFile",
-        "title": "C-mantic: Add Definition in this file"
+        "title": "Add Definition in this file",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.addDefinitions",
-        "title": "C-mantic: Add Definitions..."
+        "title": "Add Definitions...",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.addDeclaration",
-        "title": "C-mantic: Add Declaration"
+        "title": "Add Declaration",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.moveDefinitionToMatchingSourceFile",
-        "title": "C-mantic: Move Definition to matching source file"
+        "title": "Move Definition to matching source file",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.moveDefinitionIntoOrOutOfClass",
-        "title": "C-mantic: Move Definition into/out-of class body"
+        "title": "Move Definition into/out-of class body",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.generateGetterSetter",
-        "title": "C-mantic: Generate Getter and Setter Member Functions"
+        "title": "Generate Getter and Setter Member Functions",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.generateGetter",
-        "title": "C-mantic: Generate Getter Member Function"
+        "title": "Generate Getter Member Function",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.generateSetter",
-        "title": "C-mantic: Generate Setter Member Function"
+        "title": "Generate Setter Member Function",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.generateEqualityOperators",
-        "title": "C-mantic: Generate Equality Operators"
+        "title": "Generate Equality Operators",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.generateStreamOutputOperator",
-        "title": "C-mantic: Generate Stream Output Operator"
+        "title": "Generate Stream Output Operator",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.createMatchingSourceFile",
-        "title": "C-mantic: Create Matching Source File"
+        "title": "Create Matching Source File",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.addHeaderGuard",
-        "title": "C-mantic: Add Header Guard"
+        "title": "Add Header Guard",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.addInclude",
-        "title": "C-mantic: Add Include"
+        "title": "Add Include",
+        "category": "C-mantic"
       },
       {
         "command": "cmantic.switchHeaderSourceInWorkspace",
-        "title": "Switch Header/Source in Workspace"
+        "title": "Switch Header/Source in Workspace",
+        "category": "C-mantic"
       }
     ],
     "menus": {

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -1058,7 +1058,7 @@ export default class CSymbol extends SourceSymbol {
         return new ProposedPosition(this.bodyStart(), {
             after: true,
             nextTo: true,
-            emptyScope: true
+            indent: true
         });
     }
 }

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -28,6 +28,8 @@ export default class CSymbol extends SourceSymbol {
             this.parent = new CSymbol(symbol.parent, document);
         }
 
+        this.selectionRange = parse.getRangeOfSymbolName(this);
+
         this.range = this.range.with(this.range.start, parse.getEndOfStatement(this.document, this.range.end));
     }
 

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -170,9 +170,9 @@ export default class CSymbol extends SourceSymbol {
         const ranges: vscode.Range[] = [];
         let start: vscode.Position | undefined;
 
-        if (access === util.AccessLevel.private && this.kind === vscode.SymbolKind.Class) {
+        if (access === util.AccessLevel.private && this.isClass()) {
             start = this.bodyStart();
-        } else if (access === util.AccessLevel.public && this.kind === vscode.SymbolKind.Struct) {
+        } else if (access === util.AccessLevel.public && this.isStruct()) {
             start = this.bodyStart();
         }
 
@@ -344,7 +344,7 @@ export default class CSymbol extends SourceSymbol {
 
     async scopeString(target: SourceDocument, position: vscode.Position, namespacesOnly?: boolean): Promise<string> {
         let scopeString = '';
-        const scopes = (this.isClassOrStruct() || this.kind === vscode.SymbolKind.Namespace)
+        const scopes = (this.isClassOrStruct() || this.isNamespace())
                 ? [...this.scopes(), this]
                 : this.scopes();
 
@@ -433,7 +433,7 @@ export default class CSymbol extends SourceSymbol {
     childNamespaces(): CSymbol[] {
         const namespaces: CSymbol[] = [];
         this.children.forEach(child => {
-            if (child.kind === vscode.SymbolKind.Namespace) {
+            if (child.isNamespace()) {
                 namespaces.push(new CSymbol(child, this.document));
             }
         });
@@ -656,7 +656,7 @@ export default class CSymbol extends SourceSymbol {
     }
 
     isNestedNamespace(): boolean {
-        return this.kind === vscode.SymbolKind.Namespace && !/\bnamespace\b/.test(this.parsableLeadingText);
+        return this.isNamespace() && !/\bnamespace\b/.test(this.parsableLeadingText);
     }
 
     isTypedef(): boolean {

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -333,11 +333,15 @@ export default class CSymbol extends SourceSymbol {
         const allScopes: string[] = [];
 
         this.scopes().forEach(scope => {
-            allScopes.push(...scope.namedScopes);
+            if (!scope.isNamespace()) {
+                allScopes.push(...scope.namedScopes);
+            }
             allScopes.push(scope.templatedName(true));
         });
 
-        allScopes.push(...this.namedScopes);
+        if (!this.isNamespace()) {
+            allScopes.push(...this.namedScopes);
+        }
 
         return allScopes;
     }

--- a/src/ProposedPosition.ts
+++ b/src/ProposedPosition.ts
@@ -8,8 +8,7 @@ export interface PositionOptions {
     before?: boolean;
     after?: boolean;
     nextTo?: boolean;       // Signals to not put a blank line between.
-    emptyScope?: boolean;   // Signals that the position is in an empty scope and may need to be indented.
-    inNamespace?: boolean;  // Used with emptyScope, since namespace indentation is controlled by user settings.
+    indent?: boolean;       // Signals that text should be indented relative to the positions line.
 }
 
 export class ProposedPosition extends Position {
@@ -29,7 +28,7 @@ export class ProposedPosition extends Position {
         }
     }
 
-    formatTextToInsert(insertText: string, sourceDoc: SourceDocument): Promise<string> {
+    formatTextToInsert(insertText: string, sourceDoc: SourceDocument): string {
         return formatTextToInsert(insertText, this, sourceDoc);
     }
 }
@@ -43,16 +42,15 @@ export class TargetLocation {
         this.sourceDoc = sourceDoc;
     }
 
-    formatTextToInsert(insertText: string): Promise<string> {
+    formatTextToInsert(insertText: string): string {
         return formatTextToInsert(insertText, this.position, this.sourceDoc);
     }
 }
 
-async function formatTextToInsert(
+function formatTextToInsert(
     insertText: string, position: ProposedPosition, sourceDoc: SourceDocument
-): Promise<string> {
-    if (position.options.emptyScope && (!position.options.inNamespace
-            || (position.options.inNamespace && await util.shouldIndentNamespaceBody(sourceDoc)))) {
+): string {
+    if (position.options.indent) {
         insertText = insertText.replace(/^/gm, util.indentation());
     }
 

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -308,6 +308,8 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
                 return declarationOrPosition.options.relativeTo !== undefined
                         ? sourceDoc.getSymbol(declarationOrPosition.options.relativeTo.start)
                         : sourceDoc.getSymbol(declarationOrPosition);
+            } else if (declarationOrPosition instanceof CSymbol) {
+                return declarationOrPosition;
             } else {
                 return new CSymbol(declarationOrPosition, sourceDoc);
             }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -537,7 +537,6 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
                 if (targetNamespace.children.length === 0) {
                     return new ProposedPosition(targetNamespace.bodyStart(), {
                         after: true,
-                        nextTo: true,
                         emptyScope: true,
                         inNamespace: true
                     });

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -537,8 +537,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
                 if (targetNamespace.children.length === 0) {
                     return new ProposedPosition(targetNamespace.bodyStart(), {
                         after: true,
-                        emptyScope: true,
-                        inNamespace: true
+                        indent: scope.children[0].range.start.character > scope.range.start.character
                     });
                 }
 

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -71,6 +71,28 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
         return SourceFile.findMatchingSymbol(target, this.symbols, this) as CSymbol | undefined;
     }
 
+    async allFunctions(): Promise<CSymbol[]> {
+        if (!this.symbols) {
+            this.symbols = await this.executeSourceSymbolProvider();
+        }
+
+        const sourceDoc = this;
+
+        return function findFunctions(symbols: SourceSymbol[]): CSymbol[] {
+            const functions: CSymbol[] = [];
+
+            symbols.forEach(symbol => {
+                if (symbol.isFunction()) {
+                    functions.push(new CSymbol(symbol, sourceDoc));
+                } else if (symbol.children.length > 0) {
+                    functions.push(...findFunctions(symbol.children));
+                }
+            });
+
+            return functions;
+        } (this.symbols);
+    }
+
     async namespaces(): Promise<CSymbol[]> {
         if (!this.symbols) {
             this.symbols = await this.executeSourceSymbolProvider();

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -413,7 +413,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
 
         let checkedFunctionCount = 0;
         for (const symbol of before) {
-            if (checkedFunctionCount > 4) {
+            if (checkedFunctionCount > 5) {
                 break;
             }
             const functionSymbol = new CSymbol(symbol, this);
@@ -453,7 +453,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
 
         checkedFunctionCount = 0;
         for (const symbol of after) {
-            if (checkedFunctionCount > 4) {
+            if (checkedFunctionCount > 5) {
                 break;
             }
             const functionSymbol = new CSymbol(symbol, this);

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -580,7 +580,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
     private static indexOfSymbol(symbol: SourceSymbol, siblings: SourceSymbol[]): number {
         const declarationSelectionRange = symbol.selectionRange;
         return siblings.findIndex(sibling => {
-            return sibling.selectionRange.isEqual(declarationSelectionRange);
+            return sibling.selectionRange.start.isEqual(declarationSelectionRange.start);
         });
     }
 }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -101,7 +101,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
 
         const namespaces: CSymbol[] = [];
         this.symbols.forEach(symbol => {
-            if (symbol.kind === vscode.SymbolKind.Namespace) {
+            if (symbol.isNamespace()) {
                 namespaces.push(new CSymbol(symbol, this));
             }
         });
@@ -528,7 +528,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
 
     private async findPositionInParentNamespace(symbol: CSymbol): Promise<ProposedPosition | undefined> {
         for (const scope of symbol.scopes().reverse()) {
-            if (scope.kind === vscode.SymbolKind.Namespace) {
+            if (scope.isNamespace()) {
                 const targetNamespace = await this.findMatchingSymbol(scope);
                 if (!targetNamespace) {
                     continue;

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -74,16 +74,14 @@ export default class SourceFile {
     }
 
     async findDefintions(position: vscode.Position): Promise<vscode.Location[]> {
-        const definitionResults = await vscode.commands.executeCommand<vscode.Location[] | vscode.LocationLink[]>(
+        const definitionResults = await vscode.commands.executeCommand<util.LocationType[]>(
                 'vscode.executeDefinitionProvider', this.uri, position);
-
         return util.makeLocationArray(definitionResults);
     }
 
     async findDeclarations(position: vscode.Position): Promise<vscode.Location[]> {
-        const declarationResults = await vscode.commands.executeCommand<vscode.Location[] | vscode.LocationLink[]>(
+        const declarationResults = await vscode.commands.executeCommand<util.LocationType[]>(
                 'vscode.executeDeclarationProvider', this.uri, position);
-
         return util.makeLocationArray(declarationResults);
     }
 
@@ -91,7 +89,6 @@ export default class SourceFile {
         if (!this.symbols) {
             this.symbols = await this.executeSourceSymbolProvider();
         }
-
         return SourceFile.findMatchingSymbol(target, this.symbols);
     }
 

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -107,7 +107,7 @@ export default class SourceFile {
         }
 
         for (const symbol of this.symbols) {
-            if (symbol.kind === vscode.SymbolKind.Namespace) {
+            if (symbol.isNamespace()) {
                 for (const child of symbol.children) {
                     return child.range.start.character > symbol.range.start.character;
                 }

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -98,22 +98,6 @@ export default class SourceFile {
         return cfg.headerExtensions().includes(util.fileExtension(uri.fsPath));
     }
 
-    async isNamespaceBodyIndented(): Promise<boolean> {
-        if (!this.symbols) {
-            this.symbols = await this.executeSourceSymbolProvider();
-        }
-
-        for (const symbol of this.symbols) {
-            if (symbol.isNamespace()) {
-                for (const child of symbol.children) {
-                    return child.range.start.character > symbol.range.start.character;
-                }
-            }
-        }
-
-        return false;
-    }
-
     protected static findMatchingSymbol(
         target: SourceSymbol | CSymbol, symbols: SourceSymbol[], document?: SourceDocument
     ): SourceSymbol | CSymbol | undefined {

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -42,7 +42,7 @@ export default class SourceFile {
         documentSymbols.sort(util.sortByRange);
 
         this.symbols = [];
-        documentSymbols.forEach(newSymbol => this.symbols?.push(new SourceSymbol(newSymbol, this.uri)));
+        documentSymbols.forEach(symbol => this.symbols?.push(new SourceSymbol(symbol, this.uri)));
 
         return this.symbols;
     }

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -85,15 +85,10 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
     }
 
     isFunction(): boolean {
-        switch (this.kind) {
-        case vscode.SymbolKind.Operator:
-        case vscode.SymbolKind.Method:
-        case vscode.SymbolKind.Constructor:
-        case vscode.SymbolKind.Function:
-            return true;
-        default:
-            return false;
-        }
+        return this.kind === vscode.SymbolKind.Function
+            || this.kind === vscode.SymbolKind.Method
+            || this.kind === vscode.SymbolKind.Constructor
+            || this.kind === vscode.SymbolKind.Operator;
     }
 
     isConstructor(): boolean {

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -139,8 +139,20 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         }
     }
 
+    isClass(): boolean {
+        return this.kind === vscode.SymbolKind.Class;
+    }
+
+    isStruct(): boolean {
+        return this.kind === vscode.SymbolKind.Struct;
+    }
+
     isClassOrStruct(): boolean {
         return this.kind === vscode.SymbolKind.Class || this.kind === vscode.SymbolKind.Struct;
+    }
+
+    isNamespace(): boolean {
+        return this.kind === vscode.SymbolKind.Namespace;
     }
 
     /**

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -43,11 +43,8 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
             this.signature = parent.name + '::' + this.signature;
         }
 
-        // Sort DocumentSymbol.children based on their relative position to eachother.
-        symbol.children.sort(util.sortByRange);
-
-        // Convert DocumentSymbol.children to SourceSymbols to set the children property.
         this.children = [];
+        symbol.children.sort(util.sortByRange);
         symbol.children.forEach(child => this.children.push(new SourceSymbol(child, uri, this)));
     }
 
@@ -80,7 +77,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
 
     isMemberVariable(): boolean {
         return this.parent?.isClassOrStruct() === true
-                && (this.kind === vscode.SymbolKind.Field || this.kind === vscode.SymbolKind.Property);
+            && (this.kind === vscode.SymbolKind.Field || this.kind === vscode.SymbolKind.Property);
     }
 
     isVariable(): boolean {
@@ -104,7 +101,8 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         case vscode.SymbolKind.Constructor:
         case vscode.SymbolKind.Method:
         case vscode.SymbolKind.Function:
-            return this.name === this.parent?.name || /^(?<name>[\w_][\w\d_]*)::\k<name>/.test(this.signature);
+            return (this.parent?.isClassOrStruct() && this.name === this.parent.name)
+                || this.signature.includes(this.name + '::' + this.name);
         default:
             return false;
         }
@@ -115,7 +113,8 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         case vscode.SymbolKind.Constructor:
         case vscode.SymbolKind.Method:
         case vscode.SymbolKind.Function:
-            return this.name === '~' + this.parent?.name || /^(?<name>[\w_][\w\d_]*)::~\k<name>/.test(this.signature);
+            return (this.parent?.isClassOrStruct() && this.name === '~' + this.parent.name)
+                || /(?<name>[\w_][\w\d_]*)::~\k<name>/.test(this.signature);
         default:
             return false;
         }

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -64,26 +64,18 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
             this.signature = parent.name + '::' + this.signature;
         }
 
-        // Sort docSymbol.children based on their relative position to eachother.
+        // Sort DocumentSymbol.children based on their relative position to eachother.
         symbol.children.sort(util.sortByRange);
 
-        // Convert docSymbol.children to SourceSymbols to set the children property.
+        // Convert DocumentSymbol.children to SourceSymbols to set the children property.
         this.children = [];
         symbol.children.forEach(child => this.children.push(new SourceSymbol(child, uri, this)));
     }
 
-    /**
-     * Finds the most likely definition of this SourceSymbol and only returns a result with the same base file name.
-     * Returns undefined if the most likely definition is this SourceSymbol.
-     */
     async findDefinition(): Promise<vscode.Location | undefined> {
         return util.findDefinition(this);
     }
 
-    /**
-     * Finds the most likely declaration of this SourceSymbol and only returns a result with the same base file name.
-     * Returns undefined if the most likely declaration is this SourceSymbol.
-     */
     async findDeclaration(): Promise<vscode.Location | undefined> {
         return util.findDeclaration(this);
     }

--- a/src/SubSymbol.ts
+++ b/src/SubSymbol.ts
@@ -35,18 +35,10 @@ export default class SubSymbol {
 
     isAfter(offset: number): boolean { return this.startOffset() > offset; }
 
-    /**
-     * Finds the most likely definition of this SubSymbol and only returns a result with the same base file name.
-     * Returns undefined if the most likely definition is this SubSymbol.
-     */
     async findDefinition(): Promise<vscode.Location | undefined> {
         return util.findDefinition(this);
     }
 
-    /**
-     * Finds the most likely declaration of this SubSymbol and only returns a result with the same base file name.
-     * Returns undefined if the most likely declaration is this SubSymbol.
-     */
     async findDeclaration(): Promise<vscode.Location | undefined> {
         return util.findDeclaration(this);
     }

--- a/src/addDeclaration.ts
+++ b/src/addDeclaration.ts
@@ -69,7 +69,7 @@ export async function addDeclaration(
         return;
     }
 
-    const targetPos = await definitionDoc.findPositionForFunctionDeclaration(
+    const targetPos = await definitionDoc.findSmartPositionForFunctionDeclaration(
             functionDefinition, targetDoc, parentClass, access);
 
     const declaration = await functionDefinition.getDeclarationForTargetPosition(targetDoc, targetPos);

--- a/src/addDeclaration.ts
+++ b/src/addDeclaration.ts
@@ -77,7 +77,7 @@ export async function addDeclaration(
     if (access && !parentClass?.positionHasAccess(targetPos, access)) {
         formattedDeclaration = util.accessSpecifierString(access) + targetDoc.endOfLine + formattedDeclaration;
     }
-    formattedDeclaration = await targetPos.formatTextToInsert(formattedDeclaration, targetDoc);
+    formattedDeclaration = targetPos.formatTextToInsert(formattedDeclaration, targetDoc);
 
     const workspaceEdit = new vscode.WorkspaceEdit();
     workspaceEdit.insert(targetDoc.uri, targetPos, formattedDeclaration);

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -133,13 +133,12 @@ export async function addMultipleDefinitions(
             ? sourceDoc
             : await SourceDocument.open(targetUri);
 
-    const useSmartPlacement = selectedFunctions.length <= 5;
     const workspaceEdit = new vscode.WorkspaceEdit();
 
     const p_addedDefinitions: Promise<void>[] = [];
     selectedFunctions.forEach(functionDeclaration => {
         p_addedDefinitions.push(addDefinitionToWorkspaceEdit(
-                functionDeclaration, sourceDoc, targetDoc, useSmartPlacement, workspaceEdit));
+                functionDeclaration, sourceDoc, targetDoc, workspaceEdit));
     });
     await Promise.all(p_addedDefinitions);
 
@@ -200,14 +199,11 @@ async function addDefinitionToWorkspaceEdit(
     functionDeclaration: CSymbol,
     declarationDoc: SourceDocument,
     targetDoc: SourceDocument,
-    useSmartPlacement: boolean,
     workspaceEdit: vscode.WorkspaceEdit
 ): Promise<void> {
     const p_initializers = getInitializersIfFunctionIsConstructor(functionDeclaration);
 
-    const targetPos = useSmartPlacement
-            ? await declarationDoc.findSmartPositionForFunctionDefinition(functionDeclaration, targetDoc)
-            : await declarationDoc.findPositionForFunctionDefinition(functionDeclaration, targetDoc);
+    const targetPos = await declarationDoc.findSmartPositionForFunctionDefinition(functionDeclaration, targetDoc);
 
     const functionSkeleton = await constructFunctionSkeleton(
             functionDeclaration, targetDoc, targetPos, p_initializers);

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -90,9 +90,21 @@ export async function addDefinitionInCurrentFile(): Promise<boolean | undefined>
     return addDefinition(symbol, sourceDoc, sourceDoc.uri);
 }
 
-export async function addMultipleDefinitions(
-    sourceDoc: SourceDocument, matchingUri?: vscode.Uri
+export async function addDefinitions(
+    sourceDoc?: SourceDocument, matchingUri?: vscode.Uri
 ): Promise<boolean | undefined> {
+    if (!sourceDoc) {
+        // Command was called from the command-palette
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            logger.alertError(failure.noActiveTextEditor);
+            return;
+        }
+
+        sourceDoc = new SourceDocument(editor.document);
+        matchingUri = await getMatchingHeaderSource(sourceDoc.uri);
+    }
+
     const functionDeclarations: CSymbol[] = [];
     (await sourceDoc.allFunctions()).forEach(functionSymbol => {
         if (functionSymbol.isFunctionDeclaration()) {

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -175,20 +175,7 @@ export async function addDefinition(
     if (shouldReveal) {
         editor = await vscode.window.showTextDocument(targetDoc.uri);
         const revealRange = new vscode.Range(targetPos, targetPos.translate(util.lineCount(functionSkeleton)));
-        editor.revealRange(targetDoc.validateRange(revealRange), vscode.TextEditorRevealType.InCenter);
-
-        // revealRange() sometimes doesn't work for large files, this appears to be a bug in vscode.
-        // Waiting a bit and re-executing seems to work around this issue. (BigBahss/vscode-cmantic#2)
-        setTimeout(() => {
-            if (editor && revealRange) {
-                for (const visibleRange of editor.visibleRanges) {
-                    if (visibleRange.contains(revealRange)) {
-                        return;
-                    }
-                }
-                editor.revealRange(revealRange, vscode.TextEditorRevealType.InCenter);
-            }
-        }, 500);
+        util.revealRange(editor, revealRange);
     }
 
     const workspaceEdit = new vscode.WorkspaceEdit();

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -90,18 +90,21 @@ export async function addDefinitionInCurrentFile(): Promise<boolean | undefined>
 export async function addDefinition(
     functionDeclaration: CSymbol,
     declarationDoc: SourceDocument,
-    targetUri: vscode.Uri
+    targetUri: vscode.Uri,
+    skipExistingDefinitionCheck?: boolean
 ): Promise<boolean | undefined> {
     const shouldReveal = cfg.revealNewDefinition();
-    const existingDefinition = await functionDeclaration.findDefinition();
-    if (existingDefinition) {
-        if (!shouldReveal) {
-            logger.alertInformation(failure.definitionExists);
+    if (!skipExistingDefinitionCheck) {
+        const existingDefinition = await functionDeclaration.findDefinition();
+        if (existingDefinition) {
+            if (!shouldReveal) {
+                logger.alertInformation(failure.definitionExists);
+                return;
+            }
+            const editor = await vscode.window.showTextDocument(existingDefinition.uri);
+            editor.revealRange(existingDefinition.range, vscode.TextEditorRevealType.InCenter);
             return;
         }
-        const editor = await vscode.window.showTextDocument(existingDefinition.uri);
-        editor.revealRange(existingDefinition.range, vscode.TextEditorRevealType.InCenter);
-        return;
     }
 
     const p_initializers = getInitializersIfFunctionIsConstructor(functionDeclaration);

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -108,12 +108,23 @@ export async function addMultipleDefinitions(
         return;
     }
 
-    const selectedFunctions = await promptUserToSelectFunctions(undefinedFunctions);
+    const p_selectedFunctions = promptUserToSelectFunctions(undefinedFunctions);
+
+    const functionsThatRequireVisibleDefinition = undefinedFunctions.filter(declaration => {
+        return declaration.isInline()
+            || declaration.isConstexpr()
+            || declaration.isConsteval()
+            || declaration.hasUnspecializedTemplate();
+    });
+
+    const selectedFunctions = await p_selectedFunctions;
     if (!selectedFunctions || selectedFunctions.length === 0) {
         return;
     }
 
-    const targetUri = await promptUserForDefinitionLocation(sourceDoc, matchingUri);
+    const targetUri = util.arraysShareAnyElement(selectedFunctions, functionsThatRequireVisibleDefinition)
+            ? sourceDoc.uri
+            : await promptUserForDefinitionLocation(sourceDoc, matchingUri);
     if (!targetUri) {
         return;
     }

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -153,7 +153,7 @@ export async function addDefinition(
     const targetDoc = (targetUri.fsPath === declarationDoc.uri.fsPath)
             ? declarationDoc
             : await SourceDocument.open(targetUri);
-    const targetPos = await declarationDoc.findPositionForFunctionDefinition(functionDeclaration, targetDoc);
+    const targetPos = await declarationDoc.findSmartPositionForFunctionDefinition(functionDeclaration, targetDoc);
 
     const functionSkeleton = await constructFunctionSkeleton(
             functionDeclaration, targetDoc, targetPos, p_initializers);
@@ -437,7 +437,7 @@ async function promptUserToSelectFunctions(functionDeclarations: CSymbol[]): Pro
     functionDeclarations.forEach(declaration => {
         functionItems.push({
             label: '$(symbol-function) ' + declaration.name,
-            description: declaration.text(),
+            description: declaration.text().replace(/\s+/g, ' '),
             declaration: declaration
         });
     });

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -478,10 +478,10 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             return [];
         }
 
-        const addMultipleDefinitions = new RefactorAction(addDefinitionTitle.multiple, 'cmantic.addMultipleDefinitions');
-        addMultipleDefinitions.setArguments(sourceDoc, matchingUri);
+        const addDefinitions = new RefactorAction(addDefinitionTitle.multiple, 'cmantic.addDefinitions');
+        addDefinitions.setArguments(sourceDoc, matchingUri);
 
-        return [addMultipleDefinitions];
+        return [addDefinitions];
     }
 
     private async getSourceActions(

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -188,8 +188,8 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         const addDefinitionInCurrentFile = new RefactorAction(
                 addDefinitionTitle.currentFile, 'cmantic.addDefinition');
 
-        addDefinitionInMatchingSourceFile.setArguments(declaration, sourceDoc, matchingUri);
-        addDefinitionInCurrentFile.setArguments(declaration, sourceDoc, sourceDoc.uri);
+        addDefinitionInMatchingSourceFile.setArguments(declaration, sourceDoc, matchingUri, true);
+        addDefinitionInCurrentFile.setArguments(declaration, sourceDoc, sourceDoc.uri, true);
 
         if (declaration.isConstructor()) {
             addDefinitionInCurrentFile.setTitle(addDefinitionTitle.constructorCurrentFile);

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -493,6 +493,8 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         const createMatchingSourceFile = new SourceAction(
                 'Create Matching Source File', 'cmantic.createMatchingSourceFile');
 
+        createMatchingSourceFile.setArguments(sourceDoc);
+
         if (!sourceDoc.isHeader()) {
             addHeaderGuard.disable(addHeaderGuardFailure.notHeaderFile);
             createMatchingSourceFile.disable(createSourceFileFailure.notHeaderFile);

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -111,7 +111,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         matchingUri?: vscode.Uri
     ): Promise<RefactorAction[]> {
         if (!symbol) {
-            return [];
+            return this.getFileRefactorings(context, sourceDoc, matchingUri);
         }
 
         const refactorActions = await Promise.all([
@@ -119,7 +119,8 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             this.getAddDeclarationRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
             this.getMoveDefinitionRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
             this.getGetterSetterRefactorings(rangeOrSelection, context, symbol, sourceDoc),
-            this.getClassRefactorings(context, symbol, sourceDoc)
+            this.getClassRefactorings(context, symbol, sourceDoc),
+            this.getFileRefactorings(context, sourceDoc, matchingUri)
         ]);
 
         return refactorActions.flat();
@@ -466,6 +467,21 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         generateStreamOutputOperator.setArguments(classOrStruct, sourceDoc);
 
         return [generateEqualityOperators, generateStreamOutputOperator];
+    }
+
+    private async getFileRefactorings(
+        context: vscode.CodeActionContext,
+        sourceDoc: SourceDocument,
+        matchingUri?: vscode.Uri
+    ): Promise<RefactorAction[]> {
+        if (!context.only?.contains(vscode.CodeActionKind.Refactor)) {
+            return [];
+        }
+
+        const addMultipleDefinitions = new RefactorAction(addDefinitionTitle.multiple, 'cmantic.addMultipleDefinitions');
+        addMultipleDefinitions.setArguments(sourceDoc, matchingUri);
+
+        return [addMultipleDefinitions];
     }
 
     private async getSourceActions(

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -261,7 +261,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             const parentClass = await definition.getParentClass();
             if (parentClass) {
                 const scopeName = parentClass.templatedName(true);
-                if (parentClass.kind === vscode.SymbolKind.Class) {
+                if (parentClass.isClass()) {
                     addDeclaration.setTitle(`Add Declaration in class "${scopeName}"`);
                 } else {
                     addDeclaration.setTitle(`Add Declaration in struct "${scopeName}"`);
@@ -305,7 +305,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         let declarationDoc: SourceDocument | undefined;
 
         if (definition.parent?.isClassOrStruct()) {
-            if (definition.parent.kind === vscode.SymbolKind.Class) {
+            if (definition.parent.isClass()) {
                 moveDefinitionIntoOrOutOfClass.setTitle(moveDefinitionTitle.outOfClass);
             } else {
                 moveDefinitionIntoOrOutOfClass.setTitle(moveDefinitionTitle.outOfStruct);
@@ -323,11 +323,11 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
                 declaration = await declarationDoc.getSymbol(declarationLocation.range.start);
                 moveDefinitionIntoOrOutOfClass.setArguments(definition, declarationDoc, declaration);
 
-                if (declaration?.parent?.kind === vscode.SymbolKind.Class) {
+                if (declaration?.parent?.isClass()) {
                     const scopeName = declaration.parent.templatedName(true);
                     moveDefinitionIntoOrOutOfClass.setTitle(
                             `${moveDefinitionTitle.intoClass} "${scopeName}"`);
-                } else if (declaration?.parent?.kind === vscode.SymbolKind.Struct) {
+                } else if (declaration?.parent?.isStruct()) {
                     const scopeName = declaration.parent.templatedName(true);
                     moveDefinitionIntoOrOutOfClass.setTitle(
                             `${moveDefinitionTitle.intoStruct} "${scopeName}"`);
@@ -337,7 +337,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
                     if (parentClass) {
                         declarationDoc = parentClass.document;
                         const scopeName = parentClass.templatedName(true);
-                        if (parentClass.kind === vscode.SymbolKind.Class) {
+                        if (parentClass.isClass()) {
                             moveDefinitionIntoOrOutOfClass.setTitle(
                                     `${moveDefinitionTitle.intoClass} "${scopeName}"`);
                         } else {
@@ -359,7 +359,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
                 if (parentClass) {
                     declarationDoc = parentClass.document;
                     const scopeName = parentClass.templatedName(true);
-                    if (parentClass.kind === vscode.SymbolKind.Class) {
+                    if (parentClass.isClass()) {
                         moveDefinitionIntoOrOutOfClass.setTitle(
                                 `${moveDefinitionTitle.intoClass} "${scopeName}"`);
                     } else {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -59,10 +59,11 @@ const defaultCaseStyle = CaseStyle.camelCase;
 const defaultBracedInitialization = false;
 const defaultExplicitThisPointer = false;
 
-export const baseConfigurationKey = 'C_mantic';
+export const extensionKey = 'C_mantic';
+export const cpptoolsKey = 'C_Cpp';
 
 function configuration(scope?: vscode.ConfigurationScope): vscode.WorkspaceConfiguration {
-    return vscode.workspace.getConfiguration(baseConfigurationKey, scope);
+    return vscode.workspace.getConfiguration(extensionKey, scope);
 }
 
 export function alertLevel(scope?: vscode.ConfigurationScope): AlertLevel {
@@ -283,4 +284,8 @@ export function searchExclude(scope?: vscode.ConfigurationScope): string[] {
 
 export function searchExcludeGlobPattern(scope?: vscode.ConfigurationScope): vscode.GlobPattern {
     return `{${searchExclude(scope).join(',')}}`;
+}
+
+export function cpptoolsIntellisenseIsActive(scope?: vscode.ConfigurationScope): boolean {
+     return vscode.workspace.getConfiguration(cpptoolsKey, scope).get<string>('intelliSenseEngine') === 'Default';
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -16,12 +16,6 @@ export enum CurlyBraceFormat {
     NewLine
 }
 
-export enum NamespaceIndentation {
-    Auto,
-    Always,
-    Never
-}
-
 export enum HeaderGuardStyle {
     Define,
     PragmaOnce,
@@ -45,7 +39,6 @@ const defaultHeaderExtensions = ['h', 'hpp', 'hh', 'hxx'];
 const defaultSourceExtensions = ['c', 'cpp', 'cc', 'cxx'];
 const defaultFunctionCurlyBraceFormat = CurlyBraceFormat.NewLine;
 const defaultNamespaceCurlyBraceFormat = CurlyBraceFormat.Auto;
-const defaultNamespaceIndentation = NamespaceIndentation.Auto;
 const defaultGenerateNamespaces = true;
 const defaultHeaderGuardStyle = HeaderGuardStyle.Define;
 const defaultHeaderGuardDefineFormat = '${FILE_NAME}_${EXT}';
@@ -113,20 +106,6 @@ export function namespaceCurlyBraceFormat(scope?: vscode.ConfigurationScope): Cu
         return CurlyBraceFormat.NewLine;
     default:
         return defaultNamespaceCurlyBraceFormat;
-    }
-}
-
-export function indentNamespaceBody(scope?: vscode.ConfigurationScope): NamespaceIndentation {
-    const indent = configuration(scope).get<string>('cpp.indentation.namespace');
-    switch (indent) {
-    case 'Auto':
-        return NamespaceIndentation.Auto;
-    case 'Always':
-        return NamespaceIndentation.Always;
-    case 'Never':
-        return NamespaceIndentation.Never;
-    default:
-        return defaultNamespaceIndentation;
     }
 }
 

--- a/src/createSourceFile.ts
+++ b/src/createSourceFile.ts
@@ -14,7 +14,7 @@ export const failure = {
     sourceFileExists: 'A source file already exists for this header.'
 };
 
-export async function createMatchingSourceFile(): Promise<boolean | undefined> {
+export async function createMatchingSourceFile(): Promise<vscode.Uri | undefined> {
     const currentDocument = vscode.window.activeTextEditor?.document;
     if (!currentDocument) {
         logger.alertError(failure.noActiveTextEditor);
@@ -79,7 +79,8 @@ export async function createMatchingSourceFile(): Promise<boolean | undefined> {
     const editor = await vscode.window.showTextDocument(newFileUri);
     const cursorPosition = editor.document.lineAt(0).range.end;
     editor.selection = new vscode.Selection(cursorPosition, cursorPosition);
-    return true;
+
+    return newFileUri;
 }
 
 interface FolderItem extends vscode.QuickPickItem {

--- a/src/createSourceFile.ts
+++ b/src/createSourceFile.ts
@@ -109,6 +109,7 @@ async function findSourceFolders(relativeUri: vscode.Uri): Promise<FolderItem[]>
     const fileSystemItems = await vscode.workspace.fs.readDirectory(relativeUri);
     const directories: FolderItem[] = [];
     let foundSourceFile = false;
+
     for (const fileSystemItem of fileSystemItems) {
         if (fileSystemItem[1] === vscode.FileType.Directory) {
             directories.push(...await findSourceFolders(vscode.Uri.joinPath(relativeUri, fileSystemItem[0])));
@@ -121,6 +122,7 @@ async function findSourceFolders(relativeUri: vscode.Uri): Promise<FolderItem[]>
             });
         }
     }
+
     return directories;
 }
 
@@ -174,7 +176,7 @@ function generateNamespaces(namespaces: CSymbol[], eol: string): string {
                 namespaceText += eol + eol;
             }
 
-            if (namespace.isNestedNamespace()) {
+            if (namespace.isQualifiedNamespace()) {
                 namespaceText += '::' + (namespace.isInline() ? 'inline ' : '') + namespace.name;
             } else {
                 namespaceText += (namespace.isInline() ? 'inline ' : '') + 'namespace ' + namespace.name;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,9 @@ import { CodeActionProvider } from './codeActions';
 
 
 export const extensionId = 'tdennis4496.cmantic';
+export const cpptoolsId = 'ms-vscode.cpptools';
+export const clangdId = 'llvm-vs-code-extensions.vscode-clangd';
+export const cclsId = 'ccls-project.ccls';
 
 export const logger = new Logger('C-mantic');
 
@@ -33,6 +36,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     await cacheOpenDocuments();
     registerCodeActionProvider(context);
     registerEventListeners();
+    pollExtensionsToSetLanguageServer();
     logActivation(context);
 }
 
@@ -42,6 +46,19 @@ export function deactivate(): void {
 
 export function getMatchingHeaderSource(uri: vscode.Uri): Promise<vscode.Uri | undefined> {
     return headerSourceCache.get(uri);
+}
+
+export enum LanguageServer {
+    unknown,
+    cpptools,
+    clangd,
+    ccls
+}
+
+let languageServer = LanguageServer.unknown;
+
+export function activeLanguageServer(): LanguageServer {
+    return languageServer;
 }
 
 export const commands = {
@@ -97,6 +114,7 @@ function registerEventListeners(): void {
     disposables.push(vscode.workspace.onDidOpenTextDocument(onDidOpenTextDocument));
     disposables.push(vscode.workspace.onDidCreateFiles(onDidCreateFiles));
     disposables.push(vscode.workspace.onDidChangeConfiguration(onDidChangeConfiguration));
+    disposables.push(vscode.extensions.onDidChange(setActiveLanguageServer));
 }
 
 function logActivation(context: vscode.ExtensionContext): void {
@@ -122,11 +140,37 @@ async function onDidCreateFiles(event: vscode.FileCreateEvent): Promise<void> {
 }
 
 function onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent): void {
-    if (event.affectsConfiguration(cfg.baseConfigurationKey)) {
+    if (event.affectsConfiguration(cfg.extensionKey)) {
         codeActionProvider.addDefinitionEnabled = cfg.enableAddDefinition();
         codeActionProvider.addDeclarationEnabled = cfg.enableAddDeclaration();
         codeActionProvider.moveDefinitionEnabled = cfg.enableMoveDefinition();
         codeActionProvider.generateGetterSetterEnabled = cfg.enableGenerateGetterSetter();
+    }
+
+    if (event.affectsConfiguration(cfg.cpptoolsKey)) {
+        setActiveLanguageServer();
+    }
+}
+
+function pollExtensionsToSetLanguageServer(): void {
+    let i = 0;
+    const timer = setInterval(() => {
+        setActiveLanguageServer();
+        if (languageServer !== LanguageServer.unknown || ++i > 15) {
+            clearInterval(timer);
+        }
+    }, 1000);
+}
+
+function setActiveLanguageServer(): void {
+    if (vscode.extensions.getExtension(cpptoolsId)?.isActive && cfg.cpptoolsIntellisenseIsActive()) {
+        languageServer = LanguageServer.cpptools;
+    } else if (vscode.extensions.getExtension(clangdId)?.isActive) {
+        languageServer = LanguageServer.clangd;
+    } else if (vscode.extensions.getExtension(cclsId)?.isActive) {
+        languageServer = LanguageServer.ccls;
+    } else {
+        languageServer = LanguageServer.unknown;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,9 @@ import * as cfg from './configuration';
 import * as util from './utility';
 import Logger from './Logger';
 import HeaderSourceCache from './HeaderSourceCache';
-import { addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile } from './addDefinition';
+import {
+    addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile, addMultipleDefinitions
+} from './addDefinition';
 import { addDeclaration } from './addDeclaration';
 import { moveDefinitionToMatchingSourceFile, moveDefinitionIntoOrOutOfClass } from './moveDefinition';
 import {
@@ -45,6 +47,7 @@ export function getMatchingHeaderSource(uri: vscode.Uri): Promise<vscode.Uri | u
 export const commands = {
     'cmantic.addDefinitionInSourceFile': addDefinitionInSourceFile,
     'cmantic.addDefinitionInCurrentFile': addDefinitionInCurrentFile,
+    'cmantic.addMultipleDefinitions': addMultipleDefinitions,
     'cmantic.addDefinition': addDefinition,
     'cmantic.addDeclaration': addDeclaration,
     'cmantic.moveDefinitionToMatchingSourceFile': moveDefinitionToMatchingSourceFile,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as util from './utility';
 import Logger from './Logger';
 import HeaderSourceCache from './HeaderSourceCache';
 import {
-    addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile, addMultipleDefinitions
+    addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile, addDefinitions
 } from './addDefinition';
 import { addDeclaration } from './addDeclaration';
 import { moveDefinitionToMatchingSourceFile, moveDefinitionIntoOrOutOfClass } from './moveDefinition';
@@ -64,7 +64,7 @@ export function activeLanguageServer(): LanguageServer {
 export const commands = {
     'cmantic.addDefinitionInSourceFile': addDefinitionInSourceFile,
     'cmantic.addDefinitionInCurrentFile': addDefinitionInCurrentFile,
-    'cmantic.addMultipleDefinitions': addMultipleDefinitions,
+    'cmantic.addDefinitions': addDefinitions,
     'cmantic.addDefinition': addDefinition,
     'cmantic.addDeclaration': addDeclaration,
     'cmantic.moveDefinitionToMatchingSourceFile': moveDefinitionToMatchingSourceFile,

--- a/src/generateGetterSetter.ts
+++ b/src/generateGetterSetter.ts
@@ -232,12 +232,12 @@ async function getTargetForAccessorDefinition(
             if (matchingUri && !accessor.memberVariable.hasUnspecializedTemplate()) {
                 const targetDoc = await SourceDocument.open(matchingUri);
                 return new TargetLocation(
-                        await classDoc.findPositionForFunctionDefinition(declarationPos, targetDoc), targetDoc);
+                        await classDoc.findSmartPositionForFunctionDefinition(declarationPos, targetDoc), targetDoc);
             }
         }
         // fallthrough
     case cfg.DefinitionLocation.CurrentFile:
         return new TargetLocation(
-                await classDoc.findPositionForFunctionDefinition(declarationPos, classDoc), classDoc);
+                await classDoc.findSmartPositionForFunctionDefinition(declarationPos, classDoc), classDoc);
     }
 }

--- a/src/generateGetterSetter.ts
+++ b/src/generateGetterSetter.ts
@@ -109,7 +109,7 @@ export async function generateGetterSetterFor(
         relativeTo: getterPosition.options.relativeTo,
         after: true,
         nextTo: true,
-        emptyScope: getterPosition.options.emptyScope
+        indent: getterPosition.options.indent
     });
 
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -190,7 +190,7 @@ async function addNewAccessorToWorkspaceEdit(
             formattedInlineDefinition = util.accessSpecifierString(util.AccessLevel.public)
                     + classDoc.endOfLine + formattedInlineDefinition;
         }
-        formattedInlineDefinition = await declarationPos.formatTextToInsert(formattedInlineDefinition, classDoc);
+        formattedInlineDefinition = declarationPos.formatTextToInsert(formattedInlineDefinition, classDoc);
 
         workspaceEdit.insert(classDoc.uri, declarationPos, formattedInlineDefinition);
     } else {
@@ -204,10 +204,10 @@ async function addNewAccessorToWorkspaceEdit(
             formattedDeclaration = util.accessSpecifierString(util.AccessLevel.public)
                     + classDoc.endOfLine + formattedDeclaration;
         }
-        formattedDeclaration = await declarationPos.formatTextToInsert(formattedDeclaration, classDoc);
+        formattedDeclaration = declarationPos.formatTextToInsert(formattedDeclaration, classDoc);
 
         const definition = await newAccessor.definition(target.sourceDoc, target.position, curlySeparator);
-        const formattedDefinition = await target.formatTextToInsert(definition);
+        const formattedDefinition = target.formatTextToInsert(definition);
 
         workspaceEdit.insert(classDoc.uri, declarationPos, formattedDeclaration);
         workspaceEdit.insert(target.sourceDoc.uri, target.position, formattedDefinition);

--- a/src/generateOperators.ts
+++ b/src/generateOperators.ts
@@ -70,7 +70,7 @@ export async function generateEqualityOperators(
         relativeTo: equalPosition.options.relativeTo,
         after: true,
         nextTo: true,
-        emptyScope: equalPosition.options.emptyScope
+        indent: equalPosition.options.indent
     });
 
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -288,7 +288,7 @@ async function addNewOperatorToWorkspaceEdit(
             formattedInlineDefinition = util.accessSpecifierString(util.AccessLevel.public)
                     + classDoc.endOfLine + formattedInlineDefinition;
         }
-        formattedInlineDefinition = await declarationPos.formatTextToInsert(formattedInlineDefinition, classDoc);
+        formattedInlineDefinition = declarationPos.formatTextToInsert(formattedInlineDefinition, classDoc);
 
         workspaceEdit.insert(classDoc.uri, declarationPos, formattedInlineDefinition);
     } else {
@@ -298,10 +298,10 @@ async function addNewOperatorToWorkspaceEdit(
             formattedDeclaration = util.accessSpecifierString(util.AccessLevel.public)
                     + classDoc.endOfLine + formattedDeclaration;
         }
-        formattedDeclaration = await declarationPos.formatTextToInsert(formattedDeclaration, classDoc);
+        formattedDeclaration = declarationPos.formatTextToInsert(formattedDeclaration, classDoc);
 
         const definition = await newOperator.definition(target.sourceDoc, target.position, curlySeparator);
-        const formattedDefinition = await target.position.formatTextToInsert(definition, target.sourceDoc);
+        const formattedDefinition = target.position.formatTextToInsert(definition, target.sourceDoc);
 
         workspaceEdit.insert(classDoc.uri, declarationPos, formattedDeclaration);
         workspaceEdit.insert(target.sourceDoc.uri, target.position, formattedDefinition);

--- a/src/generateOperators.ts
+++ b/src/generateOperators.ts
@@ -170,7 +170,7 @@ async function promptUserForOperands(parentClass: CSymbol, prompt: string): Prom
         } else {
             operandItems.push({
                 label: '$(symbol-field) ' + operand.name,
-                description: operand.text(),
+                description: util.formatSignature(operand),
                 operand: operand,
                 picked: true
             });

--- a/src/generateOperators.ts
+++ b/src/generateOperators.ts
@@ -240,7 +240,7 @@ async function promptUserForDefinitionLocations(
             : classDoc;
     const firstDefinitionPos = (firstDefinitionItem.location === cfg.DefinitionLocation.Inline)
             ? declarationPos
-            : await classDoc.findPositionForFunctionDefinition(declarationPos, firstTargetDoc);
+            : await classDoc.findSmartPositionForFunctionDefinition(declarationPos, firstTargetDoc);
     const firstTargetLocation = new TargetLocation(firstDefinitionPos, firstTargetDoc);
 
     const secondDefinitionItem = await p_secondDefinitionItem;
@@ -255,12 +255,12 @@ async function promptUserForDefinitionLocations(
                 ? firstTargetDoc
                 : await SourceDocument.open(matchingUri);
         const secondDefinitionPos =
-                await classDoc.findPositionForFunctionDefinition(declarationPos, secondTargetDoc);
+                await classDoc.findSmartPositionForFunctionDefinition(declarationPos, secondTargetDoc);
         secondTargetLocation = new TargetLocation(secondDefinitionPos, secondTargetDoc);
     } else {
         const secondDefinitionPos = secondDefinitionItem.location === cfg.DefinitionLocation.Inline
                 ? declarationPos
-                : await classDoc.findPositionForFunctionDefinition(declarationPos);
+                : await classDoc.findSmartPositionForFunctionDefinition(declarationPos);
         secondTargetLocation = new TargetLocation(secondDefinitionPos, classDoc);
     }
 

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -75,7 +75,7 @@ export async function moveDefinitionToMatchingSourceFile(
             : await getNewPosition(targetDoc, definition);
 
     const definitionText = await definition.getDefinitionForTargetPosition(targetDoc, position, declaration, true);
-    const formattedDefinition = await position.formatTextToInsert(definitionText, targetDoc);
+    const formattedDefinition = position.formatTextToInsert(definitionText, targetDoc);
 
     const workspaceEdit = new vscode.WorkspaceEdit();
     workspaceEdit.insert(targetDoc.uri, position, formattedDefinition);
@@ -150,7 +150,7 @@ export async function moveDefinitionIntoOrOutOfClass(
         const position = await getNewPosition(classDoc, definition);
 
         const definitionText = await definition.getDefinitionForTargetPosition(classDoc, position, declaration, true);
-        const formattedDefinition = await position.formatTextToInsert(definitionText, classDoc);
+        const formattedDefinition = position.formatTextToInsert(definitionText, classDoc);
 
         const workspaceEdit = new vscode.WorkspaceEdit();
         workspaceEdit.insert(classDoc.uri, position, formattedDefinition);
@@ -185,7 +185,7 @@ export async function moveDefinitionIntoOrOutOfClass(
             if (access && !parentClass?.positionHasAccess(position, access)) {
                 formattedDefinition = util.accessSpecifierString(access) + classDoc.endOfLine + formattedDefinition;
             }
-            formattedDefinition = await position.formatTextToInsert(formattedDefinition, classDoc);
+            formattedDefinition = position.formatTextToInsert(formattedDefinition, classDoc);
 
             const workspaceEdit = new vscode.WorkspaceEdit();
             workspaceEdit.insert(classDoc.uri, position, formattedDefinition);

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -177,7 +177,7 @@ export async function moveDefinitionIntoOrOutOfClass(
                 return;
             }
 
-            const position = await definition.document.findPositionForFunctionDeclaration(
+            const position = await definition.document.findSmartPositionForFunctionDeclaration(
                     definition, parentClass.document, parentClass, access);
 
             const definitionText = await definition.getDefinitionForTargetPosition(classDoc, position);
@@ -204,7 +204,7 @@ async function getNewPosition(targetDoc: SourceDocument, declaration?: SourceSym
     }
 
     const declarationDoc = await SourceDocument.open(declaration.uri);
-    return declarationDoc.findPositionForFunctionDefinition(declaration, targetDoc);
+    return declarationDoc.findSmartPositionForFunctionDefinition(declaration, targetDoc);
 }
 
 function getDeletionRange(definition: CSymbol): vscode.Range {

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -149,6 +149,27 @@ export function getEndOfStatement(document: vscode.TextDocument, position: vscod
     return document.positionAt(document.offsetAt(position) + match[0].length);
 }
 
+export function getRangeOfSymbolName(symbol: CSymbol): vscode.Range {
+    if (symbol.document.getText(symbol.selectionRange) === symbol.name) {
+        return symbol.selectionRange;
+    }
+
+    const operatorMatch = symbol.name.match(/(?<=^operator\s*)\S+/);
+    if (operatorMatch) {
+        const nameToEndText = symbol.document.getText(new vscode.Range(symbol.selectionRange.start, symbol.range.end));
+        const indexOfOperator = nameToEndText.indexOf(operatorMatch[0], 8);
+        if (indexOfOperator !== -1) {
+            const nameStartOffset = symbol.document.offsetAt(symbol.selectionRange.start);
+            const nameEndOffset = nameStartOffset + indexOfOperator + operatorMatch[0].length;
+            return symbol.document.rangeAt(nameStartOffset, nameEndOffset);
+        }
+
+    }
+
+    const nameEnd = symbol.selectionRange.start.translate(0, symbol.name.length);
+    return symbol.selectionRange.with(symbol.selectionRange.start, nameEnd);
+}
+
 export function getIndentationRegExp(symbol: CSymbol): RegExp {
     const line = symbol.document.lineAt(symbol.trueStart);
     const indentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -35,11 +35,11 @@ function maskBalanced(text: string, left: string, right: string, keepEnclosingCh
                 const unbalancedIndex: number = +unbalancedIndexMatch[2];
                 if (unbalancedIndex < text.length) {
                     // There is an unbalanced delimiter, so we mask it and try again.
-                    text = text.substring(0, unbalancedIndex) + ' ';
+                    let maskedText = text.substring(0, unbalancedIndex) + ' ';
                     if (unbalancedIndex !== text.length - 1) {
-                        text += text.substring(unbalancedIndex + 1);
+                        maskedText += text.substring(unbalancedIndex + 1);
                     }
-                    return maskBalanced(text, left, right, keepEnclosingChars);
+                    return maskBalanced(maskedText, left, right, keepEnclosingChars);
                 }
             }
 

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -143,7 +143,7 @@ export function normalize(text: string): string {
 export function getEndOfStatement(document: vscode.TextDocument, position: vscode.Position): vscode.Position {
     const text = document.getText(new vscode.Range(position, document.lineAt(document.lineCount - 1).range.end));
     const match = text.match(/^(\s*;)*/);
-    if (!match || match.length === 0) {
+    if (!match || match.length === 0 || !match[0]) {
         return position;
     }
     return document.positionAt(document.offsetAt(position) + match[0].length);

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -138,45 +138,6 @@ export function normalize(text: string): string {
 }
 
 /**
- * Different language servers format DocumentSymbol.name differently. For instance, cpptools
- * puts function signatures in DocumentSymbol.name. The name might also be scope-qualified.
- * Returns the bare, unqualified name of the symbol.
- */
-export function getNormalizedSymbolName(documentSymbolName: string): string {
-    // Used to trim function and template parameters from the end of the name (if present).
-    function trimDelimitedFromEndOfName(name: string, leftDelim: string, rightDelim: string): string {
-        let indexOfLeftDelim = name.indexOf(leftDelim);
-        const lastIndexOfRightDelim = name.lastIndexOf(rightDelim);
-
-        if (indexOfLeftDelim > 0 && lastIndexOfRightDelim > indexOfLeftDelim) {
-            let trimmedName = name.slice(0, indexOfLeftDelim).trimEnd();
-            if (trimmedName === 'operator' || trimmedName.endsWith('::operator')) {
-                indexOfLeftDelim = name.indexOf(leftDelim, indexOfLeftDelim);
-                if (indexOfLeftDelim > 0) {
-                    trimmedName = name.slice(0, indexOfLeftDelim).trimEnd();
-                } else {
-                    trimmedName = name;
-                }
-            }
-            name = trimmedName;
-        }
-
-        return name;
-    }
-
-    documentSymbolName = trimDelimitedFromEndOfName(documentSymbolName, '(', ')');
-
-    documentSymbolName = trimDelimitedFromEndOfName(documentSymbolName, '<', '>');
-
-    const lastIndexOfScopeResolution = documentSymbolName.lastIndexOf('::');
-    if (lastIndexOfScopeResolution !== -1 && !documentSymbolName.endsWith('::')) {
-        documentSymbolName = documentSymbolName.slice(lastIndexOfScopeResolution + 2);
-    }
-
-    return documentSymbolName;
-}
-
-/**
  * DocumentSymbol.range doesn't always include the final semi-colon, so this finds the end of the last semi-colon.
  */
 export function getEndOfStatement(document: vscode.TextDocument, position: vscode.Position): vscode.Position {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as cfg from './configuration';
 import SourceDocument from './SourceDocument';
 import SourceSymbol from './SourceSymbol';
+import CSymbol from './CSymbol';
 import SubSymbol from './SubSymbol';
 import { ProposedPosition } from './ProposedPosition';
 
@@ -222,6 +223,28 @@ export function makeLocationArray(input?: vscode.Location[] | vscode.LocationLin
     }
 
     return locations;
+}
+
+export interface DeclarationDefinitionLink {
+    declaration: CSymbol;
+    definition?: vscode.Location;
+}
+
+export async function makeDeclDefLink(declaration: CSymbol): Promise<DeclarationDefinitionLink> {
+    return {
+        declaration: declaration,
+        definition: await declaration.findDefinition()
+    };
+}
+
+/**
+ * Indicates that the function requires a definition that is visible to translation unit that declares it.
+ */
+export function requiresVisibleDefinition(functionDeclaration: CSymbol): boolean {
+    return functionDeclaration.isInline()
+        || functionDeclaration.isConstexpr()
+        || functionDeclaration.isConsteval()
+        || functionDeclaration.hasUnspecializedTemplate();
 }
 
 /**

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -135,22 +135,26 @@ export async function shouldIndentNamespaceBody(declarationDoc: SourceDocument):
         || (cfgIndent === cfg.NamespaceIndentation.Auto && await declarationDoc.isNamespaceBodyIndented());
 }
 
-interface RangedObject {
-    range: vscode.Range;
-}
-
-export function sortByRange(a: RangedObject, b: RangedObject): number {
+export function sortByRange(a: { range: vscode.Range }, b: { range: vscode.Range }): number {
     return a.range.end.isAfter(b.range.end) ? 1 : -1;
 }
 
 type AnySymbol = SourceSymbol | SubSymbol;
 
+/**
+ * Finds the most likely definition of symbol and only returns a result with the same base file name.
+ * Returns undefined if the most likely definition found is the same symbol.
+ */
 export async function findDefinition(symbol: AnySymbol): Promise<vscode.Location | undefined> {
     const definitionResults = await vscode.commands.executeCommand<vscode.Location[] | vscode.LocationLink[]>(
             'vscode.executeDefinitionProvider', symbol.uri, symbol.selectionRange.start);
     return findMostLikelyResult(symbol, definitionResults);
 }
 
+/**
+ * Finds the most likely declaration of symbol and only returns a result with the same base file name.
+ * Returns undefined if the most likely declaration found is the same symbol.
+ */
 export async function findDeclaration(symbol: AnySymbol): Promise<vscode.Location | undefined> {
     const declarationResults = await vscode.commands.executeCommand<vscode.Location[] | vscode.LocationLink[]>(
             'vscode.executeDeclarationProvider', symbol.uri, symbol.selectionRange.start);

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -54,16 +54,6 @@ export function compareDirectoryPaths(directoryPath_a: string, directoryPath_b: 
                     (b_segments.length - commonLeadingDirectories - commonTrailingDirectories));
 }
 
-export function arraysIntersect<T>(array_a: T[], array_b: T[]): boolean {
-    const minLength = Math.min(array_a.length, array_b.length);
-    for (let i = 0; i < minLength; ++i) {
-        if (array_a[i] !== array_b[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
 export function arraysAreEqual<T>(array_a: T[], array_b: T[]): boolean {
     if (array_a.length !== array_b.length) {
         return false;
@@ -74,6 +64,30 @@ export function arraysAreEqual<T>(array_a: T[], array_b: T[]): boolean {
         }
     }
     return true;
+}
+
+/**
+ * Returns true if the arrays are equal, or if either array is a sub-array of
+ * the other, starting from the beginning of the arrays.
+ * For example, [1, 2, 3] and [1, 2] intersect while [1, 2, 3] and [2, 3] do not.
+ */
+export function arraysIntersect<T>(array_a: T[], array_b: T[]): boolean {
+    const minLength = Math.min(array_a.length, array_b.length);
+    for (let i = 0; i < minLength; ++i) {
+        if (array_a[i] !== array_b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function arraysShareAnyElement<T>(array_a: T[], array_b: T[]): boolean {
+    for (const element of array_a) {
+        if (array_b.includes(element)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export function uriExists(uri: vscode.Uri): boolean {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -92,6 +92,23 @@ export function containedInWorkspace(locationOrUri: vscode.Location | vscode.Uri
     return vscode.workspace.asRelativePath(locationOrUri) !== locationOrUri.fsPath;
 }
 
+export function revealRange(editor: vscode.TextEditor, range: vscode.Range): void {
+    editor.revealRange(editor.document.validateRange(range), vscode.TextEditorRevealType.InCenter);
+
+    // revealRange() sometimes doesn't work for large files, this appears to be a bug in vscode.
+    // Waiting a bit and re-executing seems to work around this issue. (BigBahss/vscode-cmantic#2)
+    setTimeout(() => {
+        if (editor && range) {
+            for (const visibleRange of editor.visibleRanges) {
+                if (visibleRange.contains(range)) {
+                    return;
+                }
+            }
+            editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        }
+    }, 500);
+}
+
 export function indentation(options?: vscode.TextEditorOptions): string {
     if (!options) {
         const editor = vscode.window.activeTextEditor;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -163,12 +163,6 @@ export function positionAfterLastNonEmptyLine(document: vscode.TextDocument): Pr
     return new ProposedPosition();
 }
 
-export async function shouldIndentNamespaceBody(declarationDoc: SourceDocument): Promise<boolean | undefined> {
-    const cfgIndent = cfg.indentNamespaceBody();
-    return cfgIndent === cfg.NamespaceIndentation.Always /* eslint-disable no-return-await */
-        || (cfgIndent === cfg.NamespaceIndentation.Auto && await declarationDoc.isNamespaceBodyIndented());
-}
-
 export function sortByRange(a: { range: vscode.Range }, b: { range: vscode.Range }): number {
     return a.range.end.isAfter(b.range.end) ? 1 : -1;
 }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -274,18 +274,20 @@ export function accessSpecifierRegexp(access: AccessLevel): RegExp {
     }
 }
 
-interface AccessItem extends vscode.QuickPickItem {
+interface AccessQuickPickItem extends vscode.QuickPickItem {
     access: AccessLevel;
 }
 
-export async function getMemberAccessFromUser(): Promise<AccessLevel | undefined> {
-    const accessItems: AccessItem[] = [
-        { label: 'public', access: AccessLevel.public },
-        { label: 'protected', access: AccessLevel.protected },
-        { label: 'private', access: AccessLevel.private }
-    ];
+const accessItems: AccessQuickPickItem[] = [
+    { label: 'public', access: AccessLevel.public },
+    { label: 'protected', access: AccessLevel.protected },
+    { label: 'private', access: AccessLevel.private }
+];
 
-    const accessItem = await vscode.window.showQuickPick<AccessItem>(accessItems, { placeHolder: 'Select member access level:' });
+export async function getMemberAccessFromUser(): Promise<AccessLevel | undefined> {
+    const accessItem = await vscode.window.showQuickPick<AccessQuickPickItem>(accessItems, {
+        placeHolder: 'Select member access level'
+    });
 
     return accessItem?.access;
 }


### PR DESCRIPTION
Adds a command/code-action `Add Definitions...` that will prompt the user to select undefined functions in the current file to add definitions for, and prompt the user for the target file. If a matching source file doesn't already exist, the user can select to create a new file (this invokes `Create Matching Source File`). Additionally, invoking `Create Matching Source File` directly will also ask the user if they want to add definitions. If the user selects a function that must be defined in the same file (inline, unspecialized templates, etc.), then it will skip the prompt to select a target file. `Create Matching Source File` will only show functions that can be defined in the source file.

`Add Definitions...` is accessible through the `Refactor...` menu or command palette.