### PR TITLE
Amend Header Guard

### DIFF
--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -227,13 +227,32 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
         return this._headerGuard;
     }
 
-    hasHeaderGuard(): boolean {
+    get hasHeaderGuard(): boolean {
         return this.headerGuardDirectives.length > 0;
+    }
+
+    get hasPragmaOnce(): boolean {
+        for (const directive of this.headerGuardDirectives) {
+            if (/^#\s*pragma\s+once\b/.test(directive.text())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    get headerGuardDefine(): string {
+        for (const directive of this.headerGuardDirectives) {
+            const match = directive.text().match(/(?<=^#\s*define\s+)[\w_][\w\d_]*\b/);
+            if (match) {
+                return match[0];
+            }
+        }
+        return '';
     }
 
     positionAfterHeaderGuard(): vscode.Position | undefined {
         for (let i = this.headerGuardDirectives.length - 1; i >= 0; --i) {
-            if (!/^#\s*endif/.test(this.headerGuardDirectives[i].text())) {
+            if (!/^#\s*endif\b/.test(this.headerGuardDirectives[i].text())) {
                 return new vscode.Position(this.headerGuardDirectives[i].range.start.line, 0);
             }
         }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -213,9 +213,9 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
                     this._headerGuard.push(this.preprocessorDirectives[i]);
                     this._headerGuard.push(this.preprocessorDirectives[i + 1]);
                     // The header guard conditional should be the last in the array, so we walk backwards.
-                    for (let i = this.conditionals.length - 1; i >= 0; --i) {
-                        if (this.conditionals[i].start === this.preprocessorDirectives[i]) {
-                            this._headerGuard.push(this.conditionals[i].end);
+                    for (let j = this.conditionals.length - 1; j >= 0; --j) {
+                        if (this.conditionals[j].start === this.preprocessorDirectives[i]) {
+                            this._headerGuard.push(this.conditionals[j].end);
                             break;
                         }
                     }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -191,7 +191,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
         return this._includedFiles;
     }
 
-    get headerGuard(): SubSymbol[] {
+    get headerGuardDirectives(): SubSymbol[] {
         if (this._headerGuard) {
             return this._headerGuard;
         }
@@ -228,13 +228,13 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
     }
 
     hasHeaderGuard(): boolean {
-        return this.headerGuard.length > 0;
+        return this.headerGuardDirectives.length > 0;
     }
 
     positionAfterHeaderGuard(): vscode.Position | undefined {
-        for (let i = this.headerGuard.length - 1; i >= 0; --i) {
-            if (!/^#\s*endif/.test(this.headerGuard[i].text())) {
-                return new vscode.Position(this.headerGuard[i].range.start.line, 0);
+        for (let i = this.headerGuardDirectives.length - 1; i >= 0; --i) {
+            if (!/^#\s*endif/.test(this.headerGuardDirectives[i].text())) {
+                return new vscode.Position(this.headerGuardDirectives[i].range.start.line, 0);
             }
         }
     }

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -69,7 +69,7 @@ export async function addDefinitionInSourceFile(): Promise<boolean | undefined> 
         return;
     }
 
-    await addDefinition(symbol, headerDoc, matchingUri);
+    return addDefinition(symbol, headerDoc, matchingUri);
 }
 
 export async function addDefinitionInCurrentFile(): Promise<boolean | undefined> {

--- a/src/addHeaderGuard.ts
+++ b/src/addHeaderGuard.ts
@@ -55,17 +55,16 @@ export async function addHeaderGuard(headerDoc?: SourceDocument): Promise<boolea
 }
 
 export function headerGuardMatchesConfiguredStyle(headerDoc: SourceDocument): boolean {
-    const headerGuardKind = cfg.headerGuardStyle(headerDoc);
+    const headerGuardStyle = cfg.headerGuardStyle(headerDoc);
 
-    if ((headerGuardKind === cfg.HeaderGuardStyle.PragmaOnce || headerGuardKind === cfg.HeaderGuardStyle.Both) && !headerDoc.hasPragmaOnce) {
+    if ((headerGuardStyle === cfg.HeaderGuardStyle.PragmaOnce || headerGuardStyle === cfg.HeaderGuardStyle.Both)
+            && !headerDoc.hasPragmaOnce) {
         return false;
     }
 
-    if (headerGuardKind === cfg.HeaderGuardStyle.Define || headerGuardKind === cfg.HeaderGuardStyle.Both) {
-        const headerGuardDefine = cfg.headerGuardDefine(headerDoc.uri);
-        if (headerGuardDefine !== headerDoc.headerGuardDefine) {
-            return false;
-        }
+    if (headerGuardStyle === cfg.HeaderGuardStyle.Define || headerGuardStyle === cfg.HeaderGuardStyle.Both
+            && cfg.headerGuardDefine(headerDoc.uri) !== headerDoc.headerGuardDefine) {
+        return false;
     }
 
     return true;
@@ -83,13 +82,13 @@ function generateHeaderGuard(
     let header = '';
     let footer = '';
 
-    const headerGuardKind = cfg.headerGuardStyle(headerDoc);
+    const headerGuardStyle = cfg.headerGuardStyle(headerDoc);
 
-    if (headerGuardKind === cfg.HeaderGuardStyle.PragmaOnce || headerGuardKind === cfg.HeaderGuardStyle.Both) {
+    if (headerGuardStyle === cfg.HeaderGuardStyle.PragmaOnce || headerGuardStyle === cfg.HeaderGuardStyle.Both) {
         header = '#pragma once' + eol;
     }
 
-    if (headerGuardKind === cfg.HeaderGuardStyle.Define || headerGuardKind === cfg.HeaderGuardStyle.Both) {
+    if (headerGuardStyle === cfg.HeaderGuardStyle.Define || headerGuardStyle === cfg.HeaderGuardStyle.Both) {
         const headerGuardDefine = cfg.headerGuardDefine(headerDoc.uri);
         header += '#ifndef ' + headerGuardDefine + eol + '#define ' + headerGuardDefine + eol;
         footer = eol + '#endif // ' + headerGuardDefine + eol;

--- a/src/addInclude.ts
+++ b/src/addInclude.ts
@@ -3,7 +3,7 @@ import SourceDocument from './SourceDocument';
 import { logger } from './extension';
 
 
-export async function addInclude(): Promise<boolean | undefined> {
+export async function addInclude(sourceDoc: SourceDocument): Promise<boolean | undefined> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         logger.alertError('No active text editor detected.');
@@ -12,9 +12,13 @@ export async function addInclude(): Promise<boolean | undefined> {
 
     const p_userInput = vscode.window.showInputBox({ value: '#include ', valueSelection: [9, 9] });
 
-    const currentPos = getCurrentPositionFromEditor(editor);
-    const sourceDoc = new SourceDocument(editor.document);
-    const newIncludePosition = sourceDoc.findPositionForNewInclude(currentPos);
+    if (!sourceDoc) {
+        // Command was called from the command-palette
+        sourceDoc = new SourceDocument(editor.document);
+    }
+
+    const currentPosition = getCurrentPositionFromEditor(editor);
+    const newIncludePosition = sourceDoc.findPositionForNewInclude(currentPosition);
 
     const userInput = await p_userInput;
     if (userInput !== undefined) {

--- a/src/addInclude.ts
+++ b/src/addInclude.ts
@@ -3,7 +3,7 @@ import SourceDocument from './SourceDocument';
 import { logger } from './extension';
 
 
-export async function addInclude(sourceDoc: SourceDocument): Promise<boolean | undefined> {
+export async function addInclude(sourceDoc?: SourceDocument): Promise<boolean | undefined> {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         logger.alertError('No active text editor detected.');
@@ -23,9 +23,9 @@ export async function addInclude(sourceDoc: SourceDocument): Promise<boolean | u
     const userInput = await p_userInput;
     if (userInput !== undefined) {
         if (/^\s*#\s*include\s*<.+>/.test(userInput)) {
-            return editor.edit(edit => edit.insert(newIncludePosition.system, userInput + sourceDoc.endOfLine));
+            return editor.edit(edit => edit.insert(newIncludePosition.system, userInput + sourceDoc!.endOfLine));
         } else if (/^\s*#\s*include\s*".+"/.test(userInput)) {
-            return editor.edit(edit => edit.insert(newIncludePosition.project, userInput + sourceDoc.endOfLine));
+            return editor.edit(edit => edit.insert(newIncludePosition.project, userInput + sourceDoc!.endOfLine));
         } else {
             logger.alertInformation('This doesn\'t seem to be a valid include statement. It wasn\'t added.');
         }

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -486,6 +486,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
                 'Create Matching Source File', 'cmantic.createMatchingSourceFile');
 
         addHeaderGuard.setArguments(sourceDoc);
+        addInclude.setArguments(sourceDoc);
         createMatchingSourceFile.setArguments(sourceDoc);
 
         if (!sourceDoc.isHeader()) {

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -499,7 +499,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         }
 
         if (sourceDoc.hasHeaderGuard()) {
-            addHeaderGuard.disable(addHeaderGuardFailure.headerGuardExists);
+            addHeaderGuard.setTitle('Amend Header Guard');
         }
 
         return [addHeaderGuard, addInclude, createMatchingSourceFile];

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -489,6 +489,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         const createMatchingSourceFile = new SourceAction(
                 'Create Matching Source File', 'cmantic.createMatchingSourceFile');
 
+        addHeaderGuard.setArguments(sourceDoc);
         createMatchingSourceFile.setArguments(sourceDoc);
 
         if (!sourceDoc.isHeader()) {

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -15,48 +15,42 @@ import { getMatchingHeaderSource } from './extension';
 
 
 export class CodeAction extends vscode.CodeAction {
-    constructor(title: string, kind: vscode.CodeActionKind, command?: string) {
+    command: vscode.Command;
+
+    constructor(title: string, command: string, kind?: vscode.CodeActionKind) {
         super(title, kind);
-        this.kind = kind;
         this.title = title;
-        if (command) {
-            this.command = { title: title, command: command };
-        }
+        this.command = { title: title, command: command };
+        this.kind = kind;
     }
 
     setTitle(title: string): void {
         this.title = title;
-        if (this.command) {
-            this.command.title = title;
-        }
+        this.command.title = title;
     }
 
     setCommand(command: string): void {
-        if (!this.command) {
-            this.command = { title: this.title, command: command };
-        } else {
-            this.command.command = command;
-        }
+        this.command.command = command;
     }
 
     setArguments(...args: any[]): void {
-        if (this.command) {
-            this.command.arguments = args;
-        }
+        this.command.arguments = args;
     }
 
-    disable(reason: string): void { this.disabled = { reason: reason }; }
+    disable(reason: string): void {
+        this.disabled = { reason: reason };
+    }
 }
 
 export class RefactorAction extends CodeAction {
-    constructor(title: string, command?: string) {
-        super(title, vscode.CodeActionKind.Refactor, command);
+    constructor(title: string, command: string) {
+        super(title, command, vscode.CodeActionKind.Refactor);
     }
 }
 
 export class SourceAction extends CodeAction {
-    constructor(title: string, command?: string) {
-        super(title, vscode.CodeActionKind.Source, command);
+    constructor(title: string, command: string) {
+        super(title, command, vscode.CodeActionKind.Source);
     }
 }
 
@@ -93,7 +87,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
 
         const [refactorings, sourceActions] = await Promise.all([
             this.getRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
-            this.getSourceActions(rangeOrSelection, sourceDoc, matchingUri)
+            this.getSourceActions(rangeOrSelection, context, sourceDoc, matchingUri)
         ]);
 
         if (token?.isCancellationRequested) {
@@ -482,6 +476,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
 
     private async getSourceActions(
         rangeOrSelection: vscode.Range | vscode.Selection,
+        context: vscode.CodeActionContext,
         sourceDoc: SourceDocument,
         matchingUri?: vscode.Uri
     ): Promise<SourceAction[]> {
@@ -504,6 +499,14 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             addHeaderGuard.setTitle('Amend Header Guard');
             if (headerGuardMatchesConfiguredStyle(sourceDoc)) {
                 addHeaderGuard.disable(addHeaderGuardFailure.headerGuardMatches);
+            } else if (!context.only?.contains(vscode.CodeActionKind.Source)) {
+                for (const directive of sourceDoc.headerGuardDirectives) {
+                    if (directive.range.contains(rangeOrSelection)) {
+                        addHeaderGuard.kind = vscode.CodeActionKind.QuickFix;
+                        addHeaderGuard.isPreferred = true;
+                        break;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Adds functionality to "amend" a header guard if it doesn't match the configured style. `Add Header Guard` will no longer be disabled in `Source Actions...` if a header guard already exists, and instead will display as `Amend Header Guard` (which is only disabled when the existing header guard matches the configuration). Additionally, if you select the header guard with the cursor, then `Amend Header Guard` will be suggested as a quick-fix (blue light-bulb).

Running `Add Header Guard` from the command-palette will ammend the header guard if possible.