### PR TITLE
Anonymous scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to the `C-mantic` extension will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - Fixed a bug where `Add Include` would place the include between the `#ifndef` and `#define` of a header guard when there are no includes yet in the file.
-- Fixed an error thrown while trying to generate code after the last line or before the first line in the file (realistically this only would happen if the file did not end in a newline and a beter position could not be found).
+- Fixed some problems stemming from anonymous scopes:
+  - Definitions can now be properly generated from anonymous namespaces.
+  - Getters/Setters can now be generated for members of anonymous sub-classes (the functions are generated as members of the named parent class).
+  - With the cursor inside of an anonymous sub-class, `Generate Equality Operators` and `Generate Stream Output Operator` will now operate on the named parent class.
+- Fixed an error thrown while trying to generate code after the last line or before the first line in the file (realistically this would only happen if the file did not end in a newline and a beter position could not be found).
 
 ## [0.7.1] - April 14, 2021
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the `C-mantic` extension will be documented in this file.
 ## [Unreleased]
 ### Fixed
 - Fixed a bug where `Add Include` would place the include between the `#ifndef` and `#define` of a header guard when there are no includes yet in the file.
+- Fixed an error thrown while trying to generate code after the last line or before the first line in the file (realistically this only would happen if the file did not end in a newline and a beter position could not be found).
 
 ## [0.7.1] - April 14, 2021
 ### Added

--- a/src/Accessor.ts
+++ b/src/Accessor.ts
@@ -18,7 +18,7 @@ enum MemberFunctionQualifier {
  */
 export abstract class Accessor {
     readonly memberVariable: CSymbol;
-    readonly parent?: CSymbol;
+    readonly namedParent?: CSymbol;
     protected qualifier: MemberFunctionQualifier;
 
     abstract name: string;
@@ -28,7 +28,7 @@ export abstract class Accessor {
 
     constructor(memberVariable: CSymbol) {
         this.memberVariable = memberVariable;
-        this.parent = memberVariable.parent;
+        this.namedParent = memberVariable.firstNamedParent();
         this.qualifier = memberVariable.isStatic() ? MemberFunctionQualifier.Static : MemberFunctionQualifier.None;
     }
 
@@ -44,7 +44,7 @@ export abstract class Accessor {
     async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
         const eol = target.endOfLine;
         const inlineSpecifier =
-            ((!this.parent || !util.containsExclusive(this.parent.range, position))
+            ((!this.namedParent || !util.containsExclusive(this.namedParent.range, position))
             && this.memberVariable.document.fileName === target.fileName)
                 ? 'inline '
                 : '';
@@ -57,8 +57,8 @@ export abstract class Accessor {
     protected memberPrefix(): string {
         if (cfg.useExplicitThisPointer(this.memberVariable.uri) && !this.isStatic) {
             return 'this->';
-        } else if (this.isStatic && this.parent) {
-            return this.parent.name + '::';
+        } else if (this.isStatic && this.namedParent) {
+            return this.namedParent.name + '::';
         } else {
             return '';
         }

--- a/src/Accessor.ts
+++ b/src/Accessor.ts
@@ -130,18 +130,19 @@ export class Setter extends Accessor {
         super(memberVariable);
         this.name = memberVariable.setterName();
         this.returnType = 'void ';
+        const memberPrefix = this.memberPrefix();
         let baseName = memberVariable.baseName();
         if (baseName !== memberVariable.name) {
             this.parameterName = baseName;
         } else {
             baseName = cfg.formatToCaseStyle(baseName, memberVariable.uri);
-            if (baseName !== memberVariable.name) {
+            if (baseName !== memberVariable.name || memberPrefix) {
                 this.parameterName = baseName;
             } else {
                 this.parameterName = baseName + '_';
             }
         }
         this.parameter = '';
-        this.body = `${this.memberPrefix() + memberVariable.name} = ${this.parameterName};`;
+        this.body = `${memberPrefix + memberVariable.name} = ${this.parameterName};`;
     }
 }

--- a/src/Accessor.ts
+++ b/src/Accessor.ts
@@ -7,39 +7,78 @@ import CSymbol from './CSymbol';
 
 const re_qualifiers = /\b(static|const|volatile|mutable)\b/g;
 
+enum MemberFunctionQualifier {
+    None,
+    Const,
+    Static
+}
+
 /**
  * Represents a new accessor member function for a member variable.
  */
-export interface Accessor {
-    readonly parent?: CSymbol;
+export abstract class Accessor {
     readonly memberVariable: CSymbol;
-    name: string;
-    isStatic: boolean;
-    returnType: string;
-    parameter: string;
-    body: string;
-    declaration: string;
-    definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string>;
+    readonly parent?: CSymbol;
+    protected qualifier: MemberFunctionQualifier;
+
+    abstract name: string;
+    abstract returnType: string;
+    abstract parameter: string;
+    abstract body: string;
+
+    constructor(memberVariable: CSymbol) {
+        this.memberVariable = memberVariable;
+        this.parent = memberVariable.parent;
+        this.qualifier = memberVariable.isStatic() ? MemberFunctionQualifier.Static : MemberFunctionQualifier.None;
+    }
+
+    get isConst(): boolean { return this.qualifier === MemberFunctionQualifier.Const; }
+
+    get isStatic(): boolean { return this.qualifier === MemberFunctionQualifier.Static; }
+
+    get declaration(): string {
+        return (this.isStatic ? 'static ' : '') + this.returnType + this.name
+                + '(' + this.parameter + ')' + (this.isConst ? ' const' : '');
+    }
+
+    async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
+        const eol = target.endOfLine;
+        const inlineSpecifier =
+            ((!this.parent || !util.containsExclusive(this.parent.range, position))
+            && this.memberVariable.document.fileName === target.fileName)
+                ? 'inline '
+                : '';
+        return this.memberVariable.combinedTemplateStatements(true, eol) + inlineSpecifier
+                + this.returnType + await this.memberVariable.scopeString(target, position)
+                + this.name + '(' + this.parameter + ')' + (this.isConst ? ' const' : '')
+                + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
+    }
+
+    protected memberPrefix(): string {
+        if (cfg.useExplicitThisPointer(this.memberVariable.uri) && !this.isStatic) {
+            return 'this->';
+        } else if (this.isStatic && this.parent) {
+            return this.parent.name + '::';
+        } else {
+            return '';
+        }
+    }
 }
 
 /**
  * Represents a new getter member function for a member variable.
  */
-export class Getter implements Accessor {
-    readonly parent?: CSymbol;
-    readonly memberVariable: CSymbol;
+export class Getter extends Accessor {
     name: string;
-    isStatic: boolean;
     returnType: string;
     parameter: string;
     body: string;
 
     constructor(memberVariable: CSymbol) {
+        super(memberVariable);
+        this.qualifier = this.isStatic ? this.qualifier : MemberFunctionQualifier.Const;
         const leadingText = memberVariable.parsableLeadingText.replace('[[', '').replace(']]', '');
-        this.parent = memberVariable.parent;
-        this.memberVariable = memberVariable;
         this.name = memberVariable.getterName();
-        this.isStatic = memberVariable.isStatic();
 
         const templateParamStart = leadingText.indexOf('<');
         const templateParamEnd = leadingText.lastIndexOf('>');
@@ -53,45 +92,19 @@ export class Getter implements Accessor {
         }
 
         this.parameter = '';
-        let memberPrefix = '';
-        if (cfg.useExplicitThisPointer(memberVariable.uri) && !this.isStatic) {
-            memberPrefix = 'this->';
-        } else if (this.isStatic && memberVariable.parent) {
-            memberPrefix = memberVariable.parent.name + '::';
-        }
-        this.body = 'return ' + memberPrefix + memberVariable.name + ';';
-    }
-
-    get declaration(): string {
-        return (this.isStatic ? 'static ' : '') + this.returnType + this.name + '()' + (this.isStatic ? '' : ' const');
-    }
-
-    async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
-        const eol = target.endOfLine;
-        const inlineSpecifier =
-            ((!this.parent || !util.containsExclusive(this.parent.range, position))
-            && this.memberVariable.document.fileName === target.fileName)
-                ? 'inline '
-                : '';
-        return this.memberVariable.combinedTemplateStatements(true, eol) + inlineSpecifier + this.returnType
-                + await this.memberVariable.scopeString(target, position) + this.name + '()'
-                + (this.isStatic ? '' : ' const') + curlySeparator + '{'
-                + eol + util.indentation() + this.body + eol + '}';
+        this.body = `return ${this.memberPrefix() + memberVariable.name};`;
     }
 }
 
 /**
  * Represents a new setter member function for a member variable.
  */
-export class Setter implements Accessor {
-    readonly parent?: CSymbol;
-    readonly memberVariable: CSymbol;
+export class Setter extends Accessor {
     name: string;
-    isStatic: boolean;
     returnType: string;
-    parameterName: string;
     parameter: string;
     body: string;
+    private parameterName: string;
 
     /**
      * This builder method is necessary since CSymbol.isPrimitive() is asynchronous.
@@ -114,10 +127,8 @@ export class Setter implements Accessor {
     }
 
     private constructor(memberVariable: CSymbol) {
-        this.parent = memberVariable.parent;
-        this.memberVariable = memberVariable;
+        super(memberVariable);
         this.name = memberVariable.setterName();
-        this.isStatic = memberVariable.isStatic();
         this.returnType = 'void ';
         let baseName = memberVariable.baseName();
         if (baseName !== memberVariable.name) {
@@ -131,28 +142,6 @@ export class Setter implements Accessor {
             }
         }
         this.parameter = '';
-        let memberPrefix = '';
-        if (cfg.useExplicitThisPointer(memberVariable.uri) && !this.isStatic) {
-            memberPrefix = 'this->';
-        } else if (this.isStatic && memberVariable.parent) {
-            memberPrefix = memberVariable.parent.name + '::';
-        }
-        this.body = `${memberPrefix + memberVariable.name} = ${this.parameterName};`;
-    }
-
-    get declaration(): string {
-        return (this.isStatic ? 'static ' : '') + 'void ' + this.name + '(' + this.parameter + ')';
-    }
-
-    async definition(target: SourceDocument, position: vscode.Position, curlySeparator: string): Promise<string> {
-        const eol = target.endOfLine;
-        const inlineSpecifier =
-            ((!this.parent || !util.containsExclusive(this.parent.range, position))
-            && this.memberVariable.document.fileName === target.fileName)
-                ? 'inline '
-                : '';
-        return this.memberVariable.combinedTemplateStatements(true, eol) + inlineSpecifier + this.returnType
-                + await this.memberVariable.scopeString(target, position) + this.name + '(' + this.parameter + ')'
-                + curlySeparator + '{' + eol + util.indentation() + this.body + eol + '}';
+        this.body = `${this.memberPrefix() + memberVariable.name} = ${this.parameterName};`;
     }
 }

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -940,6 +940,11 @@ export default class CSymbol extends SourceSymbol {
         return this._trueStart = this.document.positionAt(templateOffset);
     }
 
+    /**
+     * Only relavant to class-types and enums which can have trailing
+     * instance declarations and initializations. Returns the position
+     * past the final semi-colon of the class-type/enum definition.
+     */
     get trueEnd(): vscode.Position {
         if (this._trueEnd) {
             return this._trueEnd;

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -133,7 +133,7 @@ export default class CSymbol extends SourceSymbol {
 
         this._accessSpecifiers = [];
 
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return this._accessSpecifiers;
         }
 
@@ -257,7 +257,7 @@ export default class CSymbol extends SourceSymbol {
     findPositionForNewMemberFunction(
         access: util.AccessLevel, relativeName?: string, memberVariable?: CSymbol
     ): ProposedPosition | undefined {
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return;
         }
 
@@ -349,12 +349,12 @@ export default class CSymbol extends SourceSymbol {
 
     async scopeString(target: SourceDocument, position: vscode.Position, namespacesOnly?: boolean): Promise<string> {
         let scopeString = '';
-        const scopes = (this.isClassOrStruct() || this.isNamespace())
+        const scopes = (this.isClassType() || this.isNamespace())
                 ? [...this.scopes(), this]
                 : this.scopes();
 
         for (const scope of scopes) {
-            if (namespacesOnly && scope.isClassOrStruct()) {
+            if (namespacesOnly && scope.isClassType()) {
                 break;
             }
 
@@ -405,7 +405,7 @@ export default class CSymbol extends SourceSymbol {
                         ? this.document
                         : await SourceDocument.open(immediateScopeDefinition.uri);
                 const immediateScopeSymbol = await immediateScopeDoc.getSymbol(immediateScopeDefinition.range.start);
-                if (immediateScopeSymbol?.isClassOrStruct()) {
+                if (immediateScopeSymbol?.isClassType()) {
                     return immediateScopeSymbol;
                 }
             }
@@ -413,7 +413,7 @@ export default class CSymbol extends SourceSymbol {
     }
 
     baseClasses(): SubSymbol[] {
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return [];
         }
 
@@ -459,7 +459,7 @@ export default class CSymbol extends SourceSymbol {
      * Retruns the member variables of this class/struct that are const or a reference.
      */
     memberVariablesThatRequireInitialization(): CSymbol[] {
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return [];
         }
 
@@ -477,7 +477,7 @@ export default class CSymbol extends SourceSymbol {
     }
 
     nonStaticMemberVariables(): CSymbol[] {
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return [];
         }
 
@@ -526,7 +526,7 @@ export default class CSymbol extends SourceSymbol {
         const allTemplateStatements: string[] = [];
 
         this.scopes().forEach(scope => {
-            if (scope.isClassOrStruct() && scope.isUnspecializedTemplate())  {
+            if (scope.isClassType() && scope.isUnspecializedTemplate())  {
                 allTemplateStatements.push(...scope.templateStatements(removeDefaultArgs));
             }
         });

--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -21,6 +21,15 @@ export default class CSymbol extends SourceSymbol {
     readonly document: SourceDocument;
     parent?: CSymbol;
 
+    // Don't use these, use their getters instead.
+    private _parsableText?: string;
+    private _parsableTemplateSnippet?: string;
+    private _accessSpecifiers?: SubSymbol[];
+    private _namedScopes?: string[];
+    private _trueStart?: vscode.Position;
+    private _trueEnd?: vscode.Position;
+    private _leadingCommentStart?: vscode.Position;
+
     constructor(symbol: SourceSymbol, document: SourceDocument) {
         super(symbol, document.uri);
         this.document = document;
@@ -36,7 +45,13 @@ export default class CSymbol extends SourceSymbol {
 
     text(): string { return this.document.getText(this.range); }
 
-    fullText(): string { return this.document.getText(this.fullRange()); }
+    fullText(): string { return this.document.getText(this.fullRange); }
+
+    /**
+     * The entire range of all code associated with this symbol, including template statements,
+     * and trailing object declarations, up to (and including) the final semi-colon.
+     */
+     get fullRange(): vscode.Range { return new vscode.Range(this.trueStart, this.trueEnd); }
 
     /**
      * Returns the text contained in this symbol with comments, strings, and attributes masked with spaces.
@@ -45,10 +60,8 @@ export default class CSymbol extends SourceSymbol {
         if (this._parsableText !== undefined) {
             return this._parsableText;
         }
-        this._parsableText = parse.maskNonSourceText(this.text());
-        return this._parsableText;
+        return this._parsableText = parse.maskNonSourceText(this.text());
     }
-    private _parsableText?: string;
 
     get parsableFullText(): string {
         return this.parsableTemplateSnippet + this.parsableText;
@@ -78,44 +91,16 @@ export default class CSymbol extends SourceSymbol {
             return this._parsableTemplateSnippet;
         }
 
-        this._parsableTemplateSnippet = parse.maskNonSourceText(this._parsableTemplateSnippet);
-        return this._parsableTemplateSnippet;
-    }
-    private _parsableTemplateSnippet?: string;
-
-    fullTextWithLeadingComment(): string {
-        return this.document.getText(this.rangeWithLeadingComment());
+        return this._parsableTemplateSnippet = parse.maskNonSourceText(this._parsableTemplateSnippet);
     }
 
-    /**
-     * Returns the text contained in this symbol that comes before this.selectionRange.
-     */
-    leadingText(): string {
-        return this.document.getText(new vscode.Range(this.range.start, this.selectionRange.start));
-    }
-
-    /**
-     * Returns the text contained in this symbol that comes before this.selectionRange,
-     * including potential template statement.
-     */
-    fullLeadingText(): string {
-        return this.document.getText(new vscode.Range(this.trueStart, this.selectionRange.start));
-    }
-
-    /**
-     * Returns the range of this symbol including potential template statement.
-     */
-    fullRange(): vscode.Range { return new vscode.Range(this.trueStart, this.range.end); }
-
-    rangeWithLeadingComment(): vscode.Range {
-        return new vscode.Range(this.leadingCommentStart, this.range.end);
+    get rangeWithComments(): vscode.Range {
+        return new vscode.Range(this.leadingCommentStart, this.trailingCommentEnd());
     }
 
     startOffset(): number { return this.document.offsetAt(this.range.start); }
 
     endOffset(): number { return this.document.offsetAt(this.range.end); }
-
-    trueStartOffset(): number { return this.document.offsetAt(this.trueStart); }
 
     isBefore(offset: number): boolean { return this.endOffset() < offset; }
 
@@ -164,7 +149,6 @@ export default class CSymbol extends SourceSymbol {
 
         return this._accessSpecifiers;
     }
-    private _accessSpecifiers?: SubSymbol[];
 
     rangesOfAccess(access: util.AccessLevel): vscode.Range[] {
         const re_accessSpecifier = util.accessSpecifierRegexp(access);
@@ -328,7 +312,6 @@ export default class CSymbol extends SourceSymbol {
 
         return this._namedScopes;
     }
-    private _namedScopes?: string[];
 
     allScopes(): string[] {
         const allScopes: string[] = [];
@@ -780,7 +763,7 @@ export default class CSymbol extends SourceSymbol {
             const typeFile = new SourceFile(locations[0].uri);
             const typeSymbol = await typeFile.getSymbol(locations[0].range.start);
 
-            if (typeSymbol?.kind === vscode.SymbolKind.Enum) {
+            if (typeSymbol?.isEnum()) {
                 return true;
             } else if (typeSymbol?.mightBeTypedefOrTypeAlias()) {
                 const typeDoc = await typeFile.openDocument();
@@ -907,7 +890,7 @@ export default class CSymbol extends SourceSymbol {
         const newIndentation = line.text.substring(0, line.firstNonWhitespaceCharacterIndex);
 
         // If this CSymbol (declaration) doesn't have a comment, then we want to pull the comment from the definition.
-        if (!this.hasLeadingComment() && definition.hasLeadingComment()) {
+        if (!this.hasLeadingComment && definition.hasLeadingComment) {
             const leadingCommentRange = new vscode.Range(definition.leadingCommentStart, definition.trueStart);
             const leadingComment = definition.document.getText(leadingCommentRange);
             return leadingComment.replace(re_oldIndentation, '').replace(/\n(?!$)/gm, '\n' + newIndentation)
@@ -941,26 +924,42 @@ export default class CSymbol extends SourceSymbol {
                 return this._trueStart;
             }
 
-            this._trueStart = this.document.positionAt(namespaceStartOffset);
-            return this._trueStart;
+            return this._trueStart = this.document.positionAt(namespaceStartOffset);
         }
 
         maskedText = parse.maskAngleBrackets(maskedText).trimEnd();
         if (!maskedText.endsWith('>')) {
-            this._trueStart = this.range.start;
-            return this._trueStart;
+            return this._trueStart = this.range.start;
         }
 
         const templateOffset = maskedText.search(/\b(template\s*<\s*>\s*)$/);
         if (templateOffset === -1) {
-            this._trueStart = this.range.start;
-            return this._trueStart;
+            return this._trueStart = this.range.start;
         }
 
-        this._trueStart = this.document.positionAt(templateOffset);
-        return this._trueStart;
+        return this._trueStart = this.document.positionAt(templateOffset);
     }
-    private _trueStart?: vscode.Position;
+
+    get trueEnd(): vscode.Position {
+        if (this._trueEnd) {
+            return this._trueEnd;
+        }
+
+        if (this.parsableText.endsWith(';') || this.isNamespace() || this.isFunctionDefinition()) {
+            return this._trueEnd = this.range.end;
+        }
+
+        if (this.isClassType() || this.isEnum()) {
+            const end = this.document.lineAt(this.document.lineCount - 1).range.end;
+            const maskedText = parse.maskNonSourceText(this.document.getText(new vscode.Range(this.range.end, end)));
+            const indexOfSemiColon = maskedText.indexOf(';');
+            if (indexOfSemiColon !== -1) {
+                return this._trueEnd = this.document.positionAt(this.endOffset() + indexOfSemiColon + 1);
+            }
+        }
+
+        return this._trueEnd = this.range.end;
+    }
 
     declarationStart(): vscode.Position {
         if (!this.parsableLeadingText.startsWith('template')) {
@@ -1034,11 +1033,8 @@ export default class CSymbol extends SourceSymbol {
         return this.document.positionAt(this.startOffset() + lastMatch.index);
     }
 
-    hasLeadingComment(): boolean {
-        if (this.leadingCommentStart.isEqual(this.trueStart)) {
-            return false;
-        }
-        return true;
+    get hasLeadingComment(): boolean {
+        return !this.leadingCommentStart.isEqual(this.trueStart);
     }
 
     get leadingCommentStart(): vscode.Position {
@@ -1050,18 +1046,15 @@ export default class CSymbol extends SourceSymbol {
         const re_trimEnd = new RegExp(`[ \\t]*${this.document.endOfLine}?[ \\t]*$`);
         const maskedText = parse.maskComments(this.document.getText(before)).replace(re_trimEnd, '');
         if (!maskedText.endsWith('//') && !maskedText.endsWith('*/')) {
-            this._leadingCommentStart = this.trueStart;
-            return this._leadingCommentStart;
+            return this._leadingCommentStart = this.trueStart;
         }
 
         if (maskedText.endsWith('*/')) {
             const commentStartOffset = maskedText.lastIndexOf('/*');
             if (commentStartOffset !== -1) {
-                this._leadingCommentStart = this.document.positionAt(commentStartOffset);
-                return this._leadingCommentStart;
+                return this._leadingCommentStart = this.document.positionAt(commentStartOffset);
             }
-            this._leadingCommentStart = this.trueStart;
-            return this._leadingCommentStart;
+            return this._leadingCommentStart = this.trueStart;
         }
 
         for (let i = this.trueStart.line - 1; i >= 0; --i) {
@@ -1071,33 +1064,30 @@ export default class CSymbol extends SourceSymbol {
                 if (indexOfComment === -1) {
                     break;  // This shouldn't happen, but just in-case.
                 }
-                this._leadingCommentStart = new vscode.Position(i + 1, indexOfComment);
-                return this._leadingCommentStart;
+                return this._leadingCommentStart = new vscode.Position(i + 1, indexOfComment);
             }
         }
 
-        this._leadingCommentStart = this.trueStart;
-        return this._leadingCommentStart;
+        return this._leadingCommentStart = this.trueStart;
     }
-    private _leadingCommentStart?: vscode.Position;
 
     trailingCommentEnd(): vscode.Position {
         const documentEnd = this.document.lineAt(this.document.lineCount - 1).range.end;
-        const documentTrailingText = this.document.getText(new vscode.Range(this.range.end, documentEnd));
+        const documentTrailingText = this.document.getText(new vscode.Range(this.trueEnd, documentEnd));
 
         if (/[ \t]*\/\//.test(documentTrailingText)) {
-            return this.document.lineAt(this.range.end).range.end;
+            return this.document.lineAt(this.trueEnd).range.end;
         }
 
         if (/[ \t]*\/\*/.test(documentTrailingText)) {
             const maskedTrailingText = parse.maskComments(documentTrailingText);
             const commentEndIndex = maskedTrailingText.indexOf('*/');
             if (commentEndIndex !== -1) {
-                return this.document.positionAt(this.endOffset() + commentEndIndex + 2);
+                return this.document.positionAt(this.document.offsetAt(this.trueEnd) + commentEndIndex + 2);
             }
         }
 
-        return this.range.end;
+        return this.trueEnd;
     }
 
     private getPositionForNewChild(): ProposedPosition {

--- a/src/ProposedPosition.ts
+++ b/src/ProposedPosition.ts
@@ -68,13 +68,13 @@ function formatTextToInsert(
     const accessSpecifierIndentation = util.indentation() + '(?=(public|protected|private))';
     insertText = insertText.replace(new RegExp(accessSpecifierIndentation, 'g'), '');
 
-    const nextLine = function (): TextLine | undefined {
-        if (position.options.after) {
+    const nextLine = ((): TextLine | undefined => {
+        if (position.options.after && position.line < sourceDoc.lineCount - 1) {
             return sourceDoc.lineAt(position.line + 1);
-        } else if (position.options.before) {
+        } else if (position.options.before && position.line > 0) {
             return sourceDoc.lineAt(position.line - 1);
         }
-    } ();
+    }) ();
 
     const eol = util.endOfLine(sourceDoc);
     const newLines = (position.options.nextTo || !nextLine

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -492,7 +492,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
                 }
 
                 const linkedSymbol = await targetDoc.getSymbol(location.range.start);
-                if (!linkedSymbol || linkedSymbol.isClassOrStruct()) {
+                if (!linkedSymbol || linkedSymbol.isClassType()) {
                     /* cpptools is dumb and will return the class when finding the
                      * declaration/definition of an undeclared member function. */
                     continue;
@@ -536,7 +536,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
                 }
 
                 const linkedSymbol = await targetDoc.getSymbol(location.range.start);
-                if (!linkedSymbol || linkedSymbol.isClassOrStruct()) {
+                if (!linkedSymbol || linkedSymbol.isClassType()) {
                     /* cpptools is dumb and will return the class when finding the
                      * declaration/definition of an undeclared member function. */
                     continue;
@@ -580,7 +580,7 @@ export default class SourceDocument extends SourceFile implements vscode.TextDoc
             const parentClassLocation = await immediateScope.findDefinition();
             if (parentClassLocation?.uri.fsPath === this.uri.fsPath) {
                 parentClass = await this.getSymbol(parentClassLocation.range.start);
-                if (parentClass?.isClassOrStruct()) {
+                if (parentClass?.isClassType()) {
                     return parentClass.findPositionForNewMemberFunction(access);
                 }
             }

--- a/src/SourceFile.ts
+++ b/src/SourceFile.ts
@@ -57,7 +57,7 @@ export default class SourceFile {
                     continue;
                 }
 
-                if (sourceSymbol.children.length === 0 || sourceSymbol.selectionRange.contains(position)) {
+                if (sourceSymbol.children.length === 0) {
                     return sourceSymbol;
                 } else {
                     const child = searchSymbolTree(sourceSymbol.children);

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -160,6 +160,10 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         return this.kind === vscode.SymbolKind.Namespace;
     }
 
+    isEnum(): boolean {
+        return this.kind === vscode.SymbolKind.Enum;
+    }
+
     /**
      * This is a fuzzy test to see if the symbol might be a typedef or type-alias. This tells us that it
      * is worth it to open the document cooresponding to this.uri to resolve the typedef/type-alias.

--- a/src/SourceSymbol.ts
+++ b/src/SourceSymbol.ts
@@ -63,7 +63,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
             if (symbol.kind === vscode.SymbolKind.Property) {
                 this.kind = vscode.SymbolKind.Method;
             }
-        } else if (parent?.isClassOrStruct()) {
+        } else if (parent?.isClassType()) {
             this.signature = parent.name + '::' + this.signature;
         }
 
@@ -100,7 +100,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
     }
 
     isMemberVariable(): boolean {
-        return this.parent?.isClassOrStruct() === true
+        return this.parent?.isClassType() === true
             && (this.kind === vscode.SymbolKind.Field || this.kind === vscode.SymbolKind.Property);
     }
 
@@ -120,7 +120,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         case vscode.SymbolKind.Constructor:
         case vscode.SymbolKind.Method:
         case vscode.SymbolKind.Function:
-            return (this.parent?.isClassOrStruct() && this.name === this.parent.name)
+            return (this.parent?.isClassType() && this.name === this.parent.name)
                 || this.signature.includes(this.name + '::' + this.name);
         default:
             return false;
@@ -132,7 +132,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         case vscode.SymbolKind.Constructor:
         case vscode.SymbolKind.Method:
         case vscode.SymbolKind.Function:
-            return (this.parent?.isClassOrStruct() && this.name === '~' + this.parent.name)
+            return (this.parent?.isClassType() && this.name === '~' + this.parent.name)
                 || /(?<name>[\w_][\w\d_]*)::~\k<name>/.test(this.signature);
         default:
             return false;
@@ -147,7 +147,12 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
         return this.kind === vscode.SymbolKind.Struct;
     }
 
-    isClassOrStruct(): boolean {
+    /**
+     * Tests if this symbol is a class, struct, or union. Note that the LSP does not have a SymbolKind
+     * for unions, so it is up to the language server to provide them as classes or structs. Also note
+     * that clangd provides typedefs and type-aliases as classes, so this test is not perfect.
+     */
+    isClassType(): boolean {
         return this.kind === vscode.SymbolKind.Class || this.kind === vscode.SymbolKind.Struct;
     }
 
@@ -185,7 +190,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
     }
 
     memberVariables(): SourceSymbol[] {
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return [];
         }
 
@@ -193,7 +198,7 @@ export default class SourceSymbol extends vscode.DocumentSymbol {
     }
 
     constructors(): SourceSymbol[] {
-        if (!this.isClassOrStruct()) {
+        if (!this.isClassType()) {
             return [];
         }
 

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -209,7 +209,7 @@ interface InitializerQuickPickItem extends vscode.QuickPickItem {
 async function getInitializersIfFunctionIsConstructor(
     functionDeclaration: CSymbol
 ): Promise<Initializer[] | undefined> {
-    if (!functionDeclaration.isConstructor() || !functionDeclaration.parent?.isClassOrStruct()) {
+    if (!functionDeclaration.isConstructor() || !functionDeclaration.parent?.isClassType()) {
         return [];
     }
     const parentClass = functionDeclaration.parent;

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -457,11 +457,16 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             return [];
         }
 
-        const classOrStruct = symbol.isClassOrStruct() ? symbol : symbol.parent;
+        const classOrStruct = symbol.isClassOrStruct() && !symbol.isAnonymous() ? symbol : symbol.firstNamedParent();
+        if (!classOrStruct) {
+            return [];
+        }
+        const titleSnippet = ` for "${classOrStruct.name}"`;
+
         const generateEqualityOperators = new RefactorAction(
-                operatorTitle.equality, 'cmantic.generateEqualityOperators');
+                operatorTitle.equality + titleSnippet, 'cmantic.generateEqualityOperators');
         const generateStreamOutputOperator = new RefactorAction(
-                operatorTitle.streamOutput, 'cmantic.generateStreamOutputOperator');
+                operatorTitle.streamOutput + titleSnippet, 'cmantic.generateStreamOutputOperator');
         generateEqualityOperators.setArguments(classOrStruct, sourceDoc);
         generateStreamOutputOperator.setArguments(classOrStruct, sourceDoc);
 

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -169,7 +169,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         symbol: CSymbol
     ): boolean {
         return symbol.document.languageId === 'cpp'
-            && (symbol.isClassOrStruct() || symbol.parent?.isClassOrStruct() === true)
+            && (symbol.isClassType() || symbol.parent?.isClassType() === true)
                 && context.only?.contains(vscode.CodeActionKind.Refactor) === true;
     }
 
@@ -256,7 +256,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         } ();
 
         if ((declaration?.matches(definition) && SourceFile.isHeader(declaration.uri))
-                || definition.parent?.isClassOrStruct()) {
+                || definition.parent?.isClassType()) {
             addDeclaration.disable(addDeclarationFailure.declarationExists);
         } else {
             const parentClass = await definition.getParentClass();
@@ -306,7 +306,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         let declaration: CSymbol | undefined;
         let declarationDoc: SourceDocument | undefined;
 
-        if (definition.parent?.isClassOrStruct()) {
+        if (definition.parent?.isClassType()) {
             if (definition.parent.isClass()) {
                 moveDefinitionIntoOrOutOfClass.setTitle(moveDefinitionTitle.outOfClass);
             } else {
@@ -457,18 +457,18 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             return [];
         }
 
-        const classOrStruct = symbol.isClassOrStruct() && !symbol.isAnonymous() ? symbol : symbol.firstNamedParent();
-        if (!classOrStruct) {
+        const classSymbol = symbol.isClassType() && !symbol.isAnonymous() ? symbol : symbol.firstNamedParent();
+        if (!classSymbol) {
             return [];
         }
-        const titleSnippet = ` for "${classOrStruct.name}"`;
+        const titleSnippet = ` for "${classSymbol.name}"`;
 
         const generateEqualityOperators = new RefactorAction(
                 operatorTitle.equality + titleSnippet, 'cmantic.generateEqualityOperators');
         const generateStreamOutputOperator = new RefactorAction(
                 operatorTitle.streamOutput + titleSnippet, 'cmantic.generateStreamOutputOperator');
-        generateEqualityOperators.setArguments(classOrStruct, sourceDoc);
-        generateStreamOutputOperator.setArguments(classOrStruct, sourceDoc);
+        generateEqualityOperators.setArguments(classSymbol, sourceDoc);
+        generateStreamOutputOperator.setArguments(classSymbol, sourceDoc);
 
         return [generateEqualityOperators, generateStreamOutputOperator];
     }

--- a/src/generateGetterSetter.ts
+++ b/src/generateGetterSetter.ts
@@ -166,11 +166,13 @@ function getPositionForNewAccessorDeclaration(
     // If the new accessor is a getter, then we want to place it relative to the setter, and vice-versa.
     switch (type) {
     case AccessorType.Getter:
-        return symbol.parent?.findPositionForNewMemberFunction(util.AccessLevel.public, symbol.setterName(), symbol);
+        return symbol.firstNamedParent()?.findPositionForNewMemberFunction(
+                util.AccessLevel.public, symbol.setterName(), symbol);
     case AccessorType.Setter:
-        return symbol.parent?.findPositionForNewMemberFunction(util.AccessLevel.public, symbol.getterName(), symbol);
+        return symbol.firstNamedParent()?.findPositionForNewMemberFunction(
+                util.AccessLevel.public, symbol.getterName(), symbol);
     case AccessorType.Both:
-        return symbol.parent?.findPositionForNewMemberFunction(util.AccessLevel.public);
+        return symbol.firstNamedParent()?.findPositionForNewMemberFunction(util.AccessLevel.public);
     }
 }
 
@@ -186,7 +188,7 @@ async function addNewAccessorToWorkspaceEdit(
     if (target.sourceDoc.fileName === classDoc.fileName && target.position.isEqual(declarationPos)) {
         let formattedInlineDefinition = newAccessor.declaration + ' { ' + newAccessor.body + ' }';
         if (!skipAccessSpecifierCheck
-                && !newAccessor.parent?.positionHasAccess(declarationPos, util.AccessLevel.public)) {
+                && !newAccessor.namedParent?.positionHasAccess(declarationPos, util.AccessLevel.public)) {
             formattedInlineDefinition = util.accessSpecifierString(util.AccessLevel.public)
                     + classDoc.endOfLine + formattedInlineDefinition;
         }
@@ -200,7 +202,7 @@ async function addNewAccessorToWorkspaceEdit(
 
         let formattedDeclaration = newAccessor.declaration + ';';
         if (!skipAccessSpecifierCheck
-                && !newAccessor.parent?.positionHasAccess(declarationPos, util.AccessLevel.public)) {
+                && !newAccessor.namedParent?.positionHasAccess(declarationPos, util.AccessLevel.public)) {
             formattedDeclaration = util.accessSpecifierString(util.AccessLevel.public)
                     + classDoc.endOfLine + formattedDeclaration;
         }

--- a/src/generateOperators.ts
+++ b/src/generateOperators.ts
@@ -33,12 +33,10 @@ export async function generateEqualityOperators(
         }
 
         classDoc = new SourceDocument(editor.document);
-
         const symbol = await classDoc.getSymbol(editor.selection.start);
+        parentClass = symbol?.isClassType() && !symbol.isAnonymous() ? symbol : symbol?.firstNamedParent();
 
-        parentClass = symbol?.isClassOrStruct() ? symbol : symbol?.parent;
-
-        if (!parentClass?.isClassOrStruct()) {
+        if (!parentClass?.isClassType()) {
             logger.alertWarning(failure.noClassOrStruct);
             return;
         }
@@ -95,12 +93,10 @@ export async function generateStreamOutputOperator(
         }
 
         classDoc = new SourceDocument(editor.document);
-
         const symbol = await classDoc.getSymbol(editor.selection.start);
+        parentClass = symbol?.isClassType() && !symbol.isAnonymous() ? symbol : symbol?.firstNamedParent();
 
-        parentClass = symbol?.isClassOrStruct() ? symbol : symbol?.parent;
-
-        if (!parentClass?.isClassOrStruct()) {
+        if (!parentClass?.isClassType()) {
             logger.alertWarning(failure.noClassOrStruct);
             return;
         }

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -118,7 +118,7 @@ export async function moveDefinitionIntoOrOutOfClass(
         }
         definition = symbol;
 
-        if (definition.parent?.isClassOrStruct()) {
+        if (definition.parent?.isClassType()) {
             classDoc = sourceDoc;
         } else {
             const declarationLocation = await definition.findDeclaration();
@@ -129,12 +129,12 @@ export async function moveDefinitionIntoOrOutOfClass(
                         ? sourceDoc
                         : await SourceDocument.open(declarationLocation.uri);
                 declaration = await classDoc.getSymbol(declarationLocation.range.start);
-                if (!declaration?.parent?.isClassOrStruct()) {
+                if (!declaration?.parent?.isClassType()) {
                     declaration = undefined;
                 }
             }
 
-            if (declaration?.parent?.isClassOrStruct() === false || !classDoc) {
+            if (declaration?.parent?.isClassType() === false || !classDoc) {
                 const parentClass = await definition.getParentClass();
                 if (parentClass) {
                     classDoc = parentClass.document;
@@ -146,7 +146,7 @@ export async function moveDefinitionIntoOrOutOfClass(
         }
     }
 
-    if (definition.parent?.isClassOrStruct()) {
+    if (definition.parent?.isClassType()) {
         const position = await getNewPosition(classDoc, definition);
 
         const definitionText = await definition.getDefinitionForTargetPosition(classDoc, position, declaration, true);

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -82,8 +82,8 @@ export async function moveDefinitionToMatchingSourceFile(
     if (!declaration && SourceFile.isHeader(definition.uri)) {
         const newDeclaration = definition.newFunctionDeclaration();
         const replaceRange = cfg.alwaysMoveComments(definition.uri)
-                ? definition.rangeWithLeadingComment()
-                : definition.fullRange();
+                ? definition.rangeWithComments
+                : definition.fullRange;
         workspaceEdit.replace(definition.uri, replaceRange, newDeclaration);
     } else {
         const deletionRange = getDeletionRange(definition);
@@ -156,15 +156,15 @@ export async function moveDefinitionIntoOrOutOfClass(
         workspaceEdit.insert(classDoc.uri, position, formattedDefinition);
         const newDeclaration = definition.newFunctionDeclaration();
         const replaceRange = cfg.alwaysMoveComments(definition.uri)
-                ? definition.rangeWithLeadingComment()
-                : definition.fullRange();
+                ? definition.rangeWithComments
+                : definition.fullRange;
         workspaceEdit.replace(definition.uri, replaceRange, newDeclaration);
         return vscode.workspace.applyEdit(workspaceEdit);
     } else if (declaration) {
         const combinedDefinition = declaration.combineDefinition(definition);
 
         const workspaceEdit = new vscode.WorkspaceEdit();
-        workspaceEdit.replace(declaration.uri, declaration.fullRange(), combinedDefinition);
+        workspaceEdit.replace(declaration.uri, declaration.fullRange, combinedDefinition);
         const deletionRange = getDeletionRange(definition);
         workspaceEdit.delete(definition.uri, deletionRange);
         return vscode.workspace.applyEdit(workspaceEdit);
@@ -208,7 +208,7 @@ async function getNewPosition(targetDoc: SourceDocument, declaration?: SourceSym
 }
 
 function getDeletionRange(definition: CSymbol): vscode.Range {
-    let deletionRange = definition.rangeWithLeadingComment();
+    let deletionRange = definition.rangeWithComments;
     if (definition.document.lineAt(deletionRange.start.line - 1).isEmptyOrWhitespace) {
         deletionRange = deletionRange.union(definition.document.lineAt(deletionRange.start.line - 1).range);
     }

--- a/src/moveDefinition.ts
+++ b/src/moveDefinition.ts
@@ -209,10 +209,12 @@ async function getNewPosition(targetDoc: SourceDocument, declaration?: SourceSym
 
 function getDeletionRange(definition: CSymbol): vscode.Range {
     let deletionRange = definition.rangeWithComments;
-    if (definition.document.lineAt(deletionRange.start.line - 1).isEmptyOrWhitespace) {
+    if (deletionRange.start.line > 0
+            && definition.document.lineAt(deletionRange.start.line - 1).isEmptyOrWhitespace) {
         deletionRange = deletionRange.union(definition.document.lineAt(deletionRange.start.line - 1).range);
     }
-    if (definition.document.lineAt(deletionRange.end.line + 1).isEmptyOrWhitespace) {
+    if (deletionRange.end.line < definition.document.lineCount - 1
+            && definition.document.lineAt(deletionRange.end.line + 1).isEmptyOrWhitespace) {
         deletionRange = deletionRange.union(definition.document.lineAt(deletionRange.end.line + 1).range);
     }
     return deletionRange;

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as xregexp from 'xregexp';
 import CSymbol from './CSymbol';
+import SubSymbol from './SubSymbol';
 import { logger } from './extension';
 
 
@@ -149,8 +150,9 @@ export function getEndOfStatement(document: vscode.TextDocument, position: vscod
     return document.positionAt(document.offsetAt(position) + match[0].length);
 }
 
-export function getRangeOfSymbolName(symbol: CSymbol): vscode.Range {
-    if (symbol.document.getText(symbol.selectionRange) === symbol.name) {
+export function getRangeOfSymbolName(symbol: CSymbol | SubSymbol): vscode.Range {
+    if (symbol.document.getText(symbol.selectionRange) === symbol.name
+            || symbol.selectionRange.isEqual(symbol.range)) {
         return symbol.selectionRange;
     }
 


### PR DESCRIPTION
Fixes some problems stemming from anonymous scopes:
- Definitions can now be properly generated from anonymous namespaces.
- Getters/Setters can now be generated for members of anonymous sub-classes (the functions are generated as members of the named parent class).
- With the cursor inside of an anonymous sub-class, `Generate Equality Operators` and `Generate Stream Output Operator` will now operate on the named parent class.