### PR TITLE
Generate Relational Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ With your cursor inside of a class/struct, `Generate Equality Operators` can be 
 
 `Generate Equality Operators` will prompt you to select base classes and member variables to compare in order to generate `operator==` (`operator!=` will be generated as the negation of `operator==`). You will also be prompted for where to place the definitions of these functions (either 'Inline', 'Current File', or 'Source File'). By default, equality operators will be generated as member functions, but can also be generated as friend functions by enabling `Cpp: Friend Comparison Operators` in the settings.
 
-### **Generate Relational Operators**
+### **Generate Relational Operators (coming in v0.8.0)**
 
 With your cursor inside of a class/struct, `Generate Relational Operators` can be found in the `Refactor...` menu.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ C/C++ extension that provides generative-code commands and refactorings. Relevan
 - [Move Definition](#move-definition)
 - [Generate Getters and Setters](#generate-getters-and-setters)
 - [Generate Equality Operators](#generate-equality-operators)
+- [Generate Relational Operators](#generate-relational-operators)
 - [Generate Stream Output Operator](#generate-stream-output-operator)
 - [Create Matching Source File](#create-matching-source-file)
 - [Add Header Guard](#add-header-guard)
@@ -83,6 +84,12 @@ Additionally, for non-primitive, non-pointer data types, setters will be generat
 With your cursor inside of a class/struct, `Generate Equality Operators` can be found in the `Refactor...` menu.
 
 `Generate Equality Operators` will prompt you to select base classes and member variables to compare in order to generate `operator==` (`operator!=` will be generated as the negation of `operator==`). You will also be prompted for where to place the definitions of these functions (either 'Inline', 'Current File', or 'Source File'). By default, equality operators will be generated as member functions, but can also be generated as friend functions by enabling `Cpp: Friend Comparison Operators` in the settings.
+
+### **Generate Relational Operators**
+
+With your cursor inside of a class/struct, `Generate Relational Operators` can be found in the `Refactor...` menu.
+
+`Generate Relational Operators` will prompt you to select base classes and member variables to compare in order to generate `operator<` (`operator>`, `operator<=`, and `operator>=` are generated in terms of `operator<`). You will also be prompted for where to place the definitions of these functions (either 'Inline', 'Current File', or 'Source File'). By default, relational operators will be generated as member functions, but can also be generated as friend functions by enabling `Cpp: Friend Comparison Operators` in the settings.
 
 ### **Generate Stream Output Operator**
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
         "category": "C-mantic"
       },
       {
+        "command": "cmantic.generateRelationalOperators",
+        "title": "Generate Relational Operators",
+        "category": "C-mantic"
+      },
+      {
         "command": "cmantic.generateStreamOutputOperator",
         "title": "Generate Stream Output Operator",
         "category": "C-mantic"

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -61,7 +61,7 @@ export class ComparisonOperator extends Operator {
     }
 }
 
-export class EqualsOperator extends ComparisonOperator {
+export class EqualOperator extends ComparisonOperator {
     constructor(parent: CSymbol, operands?: Operand[]) {
         super(parent, 'operator==');
         if (operands) {
@@ -99,7 +99,7 @@ export class EqualsOperator extends ComparisonOperator {
     }
 }
 
-export class NotEqualsOperator extends ComparisonOperator {
+export class NotEqualOperator extends ComparisonOperator {
     constructor(parent: CSymbol) {
         super(parent, 'operator!=');
         if (cfg.useExplicitThisPointer(parent.uri) && !this.isFriend) {
@@ -153,6 +153,39 @@ export class LessThanOperator extends ComparisonOperator {
             this.body += `return ${cast + lhsCast} < ${cast + rhsCast};`;
         } else {
             this.body += `return ${lhs + lastOperand.name} < ${rhs + lastOperand.name};`;
+        }
+    }
+}
+
+export class GreaterThanOperator extends ComparisonOperator {
+    constructor(parent: CSymbol) {
+        super(parent, 'operator>');
+        if (this.isFriend) {
+            this.body = 'return rhs < lhs;';
+        } else {
+            this.body = 'return other < *this;';
+        }
+    }
+}
+
+export class LessThanOrEqualOperator extends ComparisonOperator {
+    constructor(parent: CSymbol) {
+        super(parent, 'operator<=');
+        if (this.isFriend) {
+            this.body = 'return !(rhs < lhs);';
+        } else {
+            this.body = 'return !(other < *this);';
+        }
+    }
+}
+
+export class GreaterThanOrEqualOperator extends ComparisonOperator {
+    constructor(parent: CSymbol) {
+        super(parent, 'operator>=');
+        if (this.isFriend) {
+            this.body = 'return !(lhs < rhs);';
+        } else {
+            this.body = 'return !(*this < other);';
         }
     }
 }

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -45,19 +45,25 @@ export abstract class Operator {
     }
 }
 
-export class EqualsOperator extends Operator {
+export class ComparisonOperator extends Operator {
     isFriend: boolean;
     name: string;
     returnType: string;
     parameters: string;
 
-    constructor(parent: CSymbol, operands?: Operand[]) {
+    constructor(parent: CSymbol, name: string) {
         super(parent);
         this.isFriend = cfg.friendComparisonOperators(parent.uri);
-        this.name = 'operator==';
+        this.name = name;
         this.returnType = 'bool ';
         const type = `const ${parent.templatedName()} &`;
         this.parameters = this.isFriend ? `${type}lhs, ${type}rhs` : `${type}other`;
+    }
+}
+
+export class EqualsOperator extends ComparisonOperator {
+    constructor(parent: CSymbol, operands?: Operand[]) {
+        super(parent, 'operator==');
         if (operands) {
             this.setOperands(operands);
         }
@@ -88,24 +94,14 @@ export class EqualsOperator extends Operator {
         });
 
         if (this.body.length > 3) {
-            this.body = 'return ' + this.body.slice(0, -3).trimEnd() + ';';
+            this.body = `return ${this.body.slice(0, -3).trimEnd()};`;
         }
     }
 }
 
-export class NotEqualsOperator extends Operator {
-    isFriend: boolean;
-    name: string;
-    returnType: string;
-    parameters: string;
-
+export class NotEqualsOperator extends ComparisonOperator {
     constructor(parent: CSymbol) {
-        super(parent);
-        this.isFriend = cfg.friendComparisonOperators(parent.uri);
-        this.name = 'operator!=';
-        this.returnType = 'bool ';
-        const type = `const ${parent.templatedName()} &`;
-        this.parameters = this.isFriend ? `${type}lhs, ${type}rhs` : `${type}other`;
+        super(parent, 'operator!=');
         if (cfg.useExplicitThisPointer(parent.uri) && !this.isFriend) {
             this.body = 'return !(*this == other);';
         } else if (this.isFriend) {
@@ -116,19 +112,9 @@ export class NotEqualsOperator extends Operator {
     }
 }
 
-export class LessThanOperator extends Operator {
-    isFriend: boolean;
-    name: string;
-    returnType: string;
-    parameters: string;
-
+export class LessThanOperator extends ComparisonOperator {
     constructor(parent: CSymbol, operands?: Operand[]) {
-        super(parent);
-        this.isFriend = cfg.friendComparisonOperators(parent.uri);
-        this.name = 'operator<';
-        this.returnType = 'bool ';
-        const type = `const ${parent.templatedName()} &`;
-        this.parameters = this.isFriend ? `${type}lhs, ${type}rhs` : `${type}other`;
+        super(parent, 'operator<');
         if (operands) {
             this.setOperands(operands);
         }

--- a/src/SourceDocument.ts
+++ b/src/SourceDocument.ts
@@ -5,8 +5,8 @@ import * as parse from './parsing';
 import SourceFile from './SourceFile';
 import SourceSymbol from './SourceSymbol';
 import CSymbol from './CSymbol';
-import { ProposedPosition } from './ProposedPosition';
 import SubSymbol from './SubSymbol';
+import { ProposedPosition } from './ProposedPosition';
 
 
 const re_preprocessorDirective = /(?<=^\s*)#.*\S(?=\s*$)/gm;

--- a/src/addDefinition.ts
+++ b/src/addDefinition.ts
@@ -4,9 +4,9 @@ import * as util from './utility';
 import SourceDocument from './SourceDocument';
 import CSymbol from './CSymbol';
 import SubSymbol from './SubSymbol';
-import { getMatchingHeaderSource, logger } from './extension';
 import { ProposedPosition } from './ProposedPosition';
 import { createMatchingSourceFile } from './createSourceFile';
+import { getMatchingHeaderSource, logger } from './extension';
 
 
 export const title = {

--- a/src/addHeaderGuard.ts
+++ b/src/addHeaderGuard.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode';
 import * as cfg from './configuration';
 import SourceDocument from './SourceDocument';
 import SubSymbol from './SubSymbol';
-import { logger } from './extension';
 import { ProposedPosition } from './ProposedPosition';
+import { logger } from './extension';
 
 
 export const failure = {

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -454,12 +454,16 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         const classOrStruct = symbol.isClassOrStruct() ? symbol : symbol.parent;
         const generateEqualityOperators = new RefactorAction(
                 operatorTitle.equality, 'cmantic.generateEqualityOperators');
+        const generateRelationalOperators = new RefactorAction(
+                operatorTitle.relational, 'cmantic.generateRelationalOperators');
         const generateStreamOutputOperator = new RefactorAction(
                 operatorTitle.streamOutput, 'cmantic.generateStreamOutputOperator');
+
         generateEqualityOperators.setArguments(classOrStruct, sourceDoc);
+        generateRelationalOperators.setArguments(classOrStruct, sourceDoc);
         generateStreamOutputOperator.setArguments(classOrStruct, sourceDoc);
 
-        return [generateEqualityOperators, generateStreamOutputOperator];
+        return [generateEqualityOperators, generateRelationalOperators, generateStreamOutputOperator];
     }
 
     private async getFileRefactorings(

--- a/src/codeActions.ts
+++ b/src/codeActions.ts
@@ -8,9 +8,9 @@ import { failure as addDefinitionFailure, title as addDefinitionTitle } from './
 import { failure as addDeclarationFailure, title as addDeclarationTitle } from './addDeclaration';
 import { failure as moveDefinitionFailure, title as moveDefinitionTitle } from './moveDefinition';
 import { failure as getterSetterFailure, title as getterSetterTitle } from './generateGetterSetter';
+import { title as operatorTitle } from './generateOperators';
 import { failure as createSourceFileFailure } from './createSourceFile';
 import { failure as addHeaderGuardFailure, headerGuardMatchesConfiguredStyle } from './addHeaderGuard';
-import { title as operatorTitle } from './generateOperators';
 import { getMatchingHeaderSource } from './extension';
 
 

--- a/src/createSourceFile.ts
+++ b/src/createSourceFile.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import * as cfg from './configuration';
 import * as util from './utility';
-import * as path from 'path';
 import SourceDocument from './SourceDocument';
 import CSymbol from './CSymbol';
 import { getMatchingHeaderSource, logger } from './extension';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
     generateGetterSetter, generateGetter, generateSetter,
     generateGetterSetterFor, generateGetterFor, generateSetterFor
 } from './generateGetterSetter';
-import { generateEqualityOperators, generateStreamOutputOperator } from './generateOperators';
+import { generateEqualityOperators, generateRelationalOperators, generateStreamOutputOperator } from './generateOperators';
 import { switchHeaderSourceInWorkspace } from './switchHeaderSource';
 import { createMatchingSourceFile } from './createSourceFile';
 import { addInclude } from './addInclude';
@@ -76,6 +76,7 @@ export const commands = {
     'cmantic.generateGetterFor': generateGetterFor,
     'cmantic.generateSetterFor': generateSetterFor,
     'cmantic.generateEqualityOperators': generateEqualityOperators,
+    'cmantic.generateRelationalOperators': generateRelationalOperators,
     'cmantic.generateStreamOutputOperator': generateStreamOutputOperator,
     'cmantic.createMatchingSourceFile': createMatchingSourceFile,
     'cmantic.addHeaderGuard': addHeaderGuard,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as util from './utility';
 import Logger from './Logger';
 import HeaderSourceCache from './HeaderSourceCache';
 import {
-    addDefinition, addDefinitionInSourceFile, addDefinitionInCurrentFile, addDefinitions
+    addDefinitionInSourceFile, addDefinitionInCurrentFile, addDefinitions, addDefinition
 } from './addDefinition';
 import { addDeclaration } from './addDeclaration';
 import { moveDefinitionToMatchingSourceFile, moveDefinitionIntoOrOutOfClass } from './moveDefinition';
@@ -12,11 +12,13 @@ import {
     generateGetterSetter, generateGetter, generateSetter,
     generateGetterSetterFor, generateGetterFor, generateSetterFor
 } from './generateGetterSetter';
-import { generateEqualityOperators, generateRelationalOperators, generateStreamOutputOperator } from './generateOperators';
-import { switchHeaderSourceInWorkspace } from './switchHeaderSource';
+import {
+    generateEqualityOperators, generateRelationalOperators, generateStreamOutputOperator
+} from './generateOperators';
 import { createMatchingSourceFile } from './createSourceFile';
-import { addInclude } from './addInclude';
 import { addHeaderGuard } from './addHeaderGuard';
+import { addInclude } from './addInclude';
+import { switchHeaderSourceInWorkspace } from './switchHeaderSource';
 import { CodeActionProvider } from './codeActions';
 
 

--- a/src/generateOperators.ts
+++ b/src/generateOperators.ts
@@ -6,7 +6,7 @@ import CSymbol from './CSymbol';
 import SubSymbol from './SubSymbol';
 import { ProposedPosition, TargetLocation } from './ProposedPosition';
 import {
-    Operand, Operator, EqualsOperator, NotEqualsOperator, LessThanOperator, StreamOutputOperator
+    Operand, Operator, EqualOperator, NotEqualOperator, LessThanOperator, StreamOutputOperator
 } from './Operator';
 import { getMatchingHeaderSource, logger } from './extension';
 
@@ -60,11 +60,11 @@ export async function generateEqualityOperators(
         return;
     }
 
-    const equalsOp = new EqualsOperator(parentClass, operands);
-    const notEqualsOp = new NotEqualsOperator(parentClass);
+    const equalOp = new EqualOperator(parentClass, operands);
+    const notEqualOp = new NotEqualOperator(parentClass);
 
     const targets = await promptUserForDefinitionLocations(
-            parentClass, classDoc, equalPosition, equalsOp.name, notEqualsOp.name);
+            parentClass, classDoc, equalPosition, equalOp.name, notEqualOp.name);
     if (!targets) {
         return;
     }
@@ -77,10 +77,10 @@ export async function generateEqualityOperators(
     });
 
     const workspaceEdit = new vscode.WorkspaceEdit();
-    await addNewOperatorToWorkspaceEdit(equalsOp, equalPosition, classDoc, targets.first, workspaceEdit);
+    await addNewOperatorToWorkspaceEdit(equalOp, equalPosition, classDoc, targets.first, workspaceEdit);
     if (targets.second) {
         await addNewOperatorToWorkspaceEdit(
-                notEqualsOp, notEqualPosition, classDoc, targets.second, workspaceEdit, true);
+                notEqualOp, notEqualPosition, classDoc, targets.second, workspaceEdit, true);
     }
 
     return vscode.workspace.applyEdit(workspaceEdit);

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as cfg from './configuration';
 import * as parse from './parsing';
-import SourceDocument from './SourceDocument';
 import SourceSymbol from './SourceSymbol';
 import CSymbol from './CSymbol';
 import SubSymbol from './SubSymbol';


### PR DESCRIPTION
Adds a command/code-action `Generate Relational Operators`, accessible through the `Refactor...` menu within a class or struct. Prompts the user to select base classes and member variables to compare in `operator<` (the other operators are generated in terms of `operator<`). Works just like `Generate Equality Operators`.