### PR TITLE
Change function signature

### DIFF
--- a/src/CSymbol.ts
+++ b/src/CSymbol.ts
@@ -309,7 +309,7 @@ export default class CSymbol extends SourceSymbol {
         for (const match of maskedScopeString.matchAll(/[\w_][\w\d_]*(\s*<\s*>)?/g)) {
             if (match.index !== undefined) {
                 const scope = scopeString.slice(match.index, match.index + match[0].length);
-                this._namedScopes.push(parse.normalize(scope));
+                this._namedScopes.push(parse.normalizeWhitespace(scope));
             }
         }
 
@@ -575,7 +575,7 @@ export default class CSymbol extends SourceSymbol {
 
     templatedName(normalize?: boolean): string {
         const templateName = this.name + this.templateParameters();
-        return normalize ? parse.normalize(templateName) : templateName;
+        return normalize ? parse.normalizeWhitespace(templateName) : templateName;
     }
 
     /**

--- a/src/CodeActionProvider.ts
+++ b/src/CodeActionProvider.ts
@@ -467,7 +467,6 @@ export class CodeActionProvider extends vscode.Disposable implements vscode.Code
                         }
                         if (!context.only?.contains(vscode.CodeActionKind.Refactor)) {
                             moveDefinitionIntoOrOutOfClass.kind = vscode.CodeActionKind.QuickFix;
-                            moveDefinitionIntoOrOutOfClass.isPreferred = true;
                             moveDefinitionIntoOrOutOfClass.diagnostics = [...context.diagnostics];
                         }
                     } else {
@@ -489,7 +488,6 @@ export class CodeActionProvider extends vscode.Disposable implements vscode.Code
                     }
                     if (!context.only?.contains(vscode.CodeActionKind.Refactor)) {
                         moveDefinitionIntoOrOutOfClass.kind = vscode.CodeActionKind.QuickFix;
-                        moveDefinitionIntoOrOutOfClass.isPreferred = true;
                         moveDefinitionIntoOrOutOfClass.diagnostics = [...context.diagnostics];
                     }
                 } else {

--- a/src/CodeActionProvider.ts
+++ b/src/CodeActionProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as cfg from './configuration';
+import * as parse from './parsing';
 import * as util from './utility';
 import SourceFile from './SourceFile';
 import SourceDocument from './SourceDocument';
@@ -78,7 +79,16 @@ export class SourceAction extends CodeAction {
     }
 }
 
-export class CodeActionProvider implements vscode.CodeActionProvider {
+class LinkedLocation extends vscode.Location {
+    readonly linkedLocation: vscode.Location;
+
+    constructor(symbol: CSymbol, linkedLocation: vscode.Location) {
+        super(symbol.uri, declarationRange(symbol));
+        this.linkedLocation = linkedLocation;
+    }
+}
+
+export class CodeActionProvider extends vscode.Disposable implements vscode.CodeActionProvider {
     static readonly metadata: vscode.CodeActionProviderMetadata = {
         providedCodeActionKinds: [
             vscode.CodeActionKind.QuickFix,
@@ -91,10 +101,44 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         ]
     };
 
-    addDefinitionEnabled: boolean = cfg.enableAddDefinition();
-    addDeclarationEnabled: boolean = cfg.enableAddDeclaration();
-    moveDefinitionEnabled: boolean = cfg.enableMoveDefinition();
-    generateGetterSetterEnabled: boolean = cfg.enableGenerateGetterSetter();
+    private addDefinitionEnabled!: boolean;
+    private addDeclarationEnabled!: boolean;
+    private moveDefinitionEnabled!: boolean;
+    private generateGetterSetterEnabled!: boolean;
+
+    private currentFunction?: LinkedLocation;
+    private changedFunction?: LinkedLocation;
+
+    private readonly disposables: vscode.Disposable[];
+
+    constructor() {
+        super(() => this.disposables.forEach(disposable => disposable.dispose()));
+        this.updateEnabledCodeActions();
+        this.disposables = [
+            vscode.workspace.onDidChangeConfiguration(event => {
+                if (event.affectsConfiguration(cfg.extensionKey)) {
+                    this.updateEnabledCodeActions();
+                }
+            }),
+            vscode.workspace.onDidChangeTextDocument(event => {
+                if (event.document.uri.fsPath === this.currentFunction?.uri.fsPath) {
+                    for (const change of event.contentChanges) {
+                        if (change.range.intersection(this.currentFunction.range)) {
+                            this.currentFunction.range = this.currentFunction.range.union(change.range);
+                            this.changedFunction = this.currentFunction;
+                        }
+                    }
+                }
+            })
+        ];
+    }
+
+    updateEnabledCodeActions(): void {
+        this.addDefinitionEnabled = cfg.enableAddDefinition();
+        this.addDeclarationEnabled = cfg.enableAddDeclaration();
+        this.moveDefinitionEnabled = cfg.enableMoveDefinition();
+        this.generateGetterSetterEnabled = cfg.enableGenerateGetterSetter();
+    }
 
     async provideCodeActions(
         document: vscode.TextDocument,
@@ -113,9 +157,25 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             return [];
         }
 
-        return context.only?.contains(vscode.CodeActionKind.Source)
-                ? this.getSourceActions(rangeOrSelection, context, sourceDoc, matchingUri)
-                : this.getRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri);
+        const codeActions = context.only?.contains(vscode.CodeActionKind.Source)
+                ? await this.getSourceActions(rangeOrSelection, context, sourceDoc, matchingUri)
+                : await this.getRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri);
+
+        setImmediate(() => this.updateTrackedFunction(symbol));
+
+        return codeActions;
+    }
+
+    private async updateTrackedFunction(symbol: CSymbol | undefined): Promise<void> {
+        if (symbol?.isFunctionDeclaration()) {
+            const definitionLocation = await symbol.findDefinition();
+            this.currentFunction = definitionLocation ? new LinkedLocation(symbol, definitionLocation) : undefined;
+        } else if (symbol?.isFunctionDefinition()) {
+            const declarationLocation = await symbol.findDeclaration();
+            this.currentFunction = declarationLocation ? new LinkedLocation(symbol, declarationLocation) : undefined;
+        } else {
+            this.currentFunction = undefined;
+        }
     }
 
     private async getRefactorings(
@@ -130,15 +190,16 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         }
 
         const refactorActions = await Promise.all([
+            this.getUpdateSignatureRefactoring(rangeOrSelection, context, symbol, sourceDoc),
             this.getAddDefinitionRefactorings(context, symbol, sourceDoc, matchingUri),
-            this.getAddDeclarationRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
+            this.getAddDeclarationRefactoring(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
             this.getMoveDefinitionRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
             this.getGetterSetterRefactorings(rangeOrSelection, context, symbol, sourceDoc, matchingUri),
             this.getClassRefactorings(context, symbol, sourceDoc),
             this.getFileRefactorings(context, sourceDoc, matchingUri)
         ]);
 
-        return refactorActions.flat();
+        return refactorActions.flat().filter((action): action is RefactorAction => action !== undefined);
     }
 
     private shouldProvideAddDefinition(
@@ -188,14 +249,57 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             && !!context.only?.contains(vscode.CodeActionKind.Refactor);
     }
 
+    private async getUpdateSignatureRefactoring(
+        rangeOrSelection: vscode.Range | vscode.Selection,
+        context: vscode.CodeActionContext,
+        symbol: CSymbol,
+        sourceDoc: SourceDocument
+    ): Promise<RefactorAction | undefined> {
+        if (!this.changedFunction) {
+            return;
+        }
+
+        const range = declarationRange(symbol);
+        if (!range.intersection(this.changedFunction.range) || !range.intersection(rangeOrSelection)) {
+            return;
+        }
+        this.changedFunction.range = range;
+
+        let title = 'Update function';
+        if (symbol.isFunctionDeclaration()) {
+            if (await symbol.findDefinition()) {
+                this.changedFunction = undefined;
+                return;
+            }
+            title += ' definition';
+        } else if (symbol.isFunctionDefinition()) {
+            if (await symbol.findDeclaration()) {
+                this.changedFunction = undefined;
+                return;
+            }
+            title += ' declaration';
+        }
+
+        const updateSignature = new RefactorAction(title, 'cmantic.updateSignature');
+        updateSignature.setArguments(symbol, sourceDoc, this.changedFunction.linkedLocation);
+
+        if (!context.only?.contains(vscode.CodeActionKind.Refactor)) {
+            updateSignature.kind = vscode.CodeActionKind.QuickFix;
+            updateSignature.isPreferred = true;
+            updateSignature.diagnostics = [...context.diagnostics];
+        }
+
+        return updateSignature;
+    }
+
     private async getAddDefinitionRefactorings(
         context: vscode.CodeActionContext,
         declaration: CSymbol,
         sourceDoc: SourceDocument,
         matchingUri?: vscode.Uri
-    ): Promise<RefactorAction[]> {
+    ): Promise<RefactorAction[] | undefined> {
         if (!this.shouldProvideAddDefinition(context, declaration)) {
-            return [];
+            return;
         }
 
         const p_existingDefinition = declaration.findDefinition();
@@ -244,15 +348,15 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         return [addDefinitionInMatchingSourceFile, addDefinitionInCurrentFile];
     }
 
-    private async getAddDeclarationRefactorings(
+    private async getAddDeclarationRefactoring(
         rangeOrSelection: vscode.Range | vscode.Selection,
         context: vscode.CodeActionContext,
         definition: CSymbol,
         sourceDoc: SourceDocument,
         matchingUri?: vscode.Uri
-    ): Promise<RefactorAction[]> {
+    ): Promise<RefactorAction | undefined> {
         if (!this.shouldProvideAddDeclaration(rangeOrSelection, context, definition)) {
-            return [];
+            return;
         }
 
         const p_existingDeclaration = definition.findDeclaration();
@@ -298,7 +402,7 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
             }
         }
 
-        return [addDeclaration];
+        return addDeclaration;
     }
 
     private async getMoveDefinitionRefactorings(
@@ -307,10 +411,10 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         definition: CSymbol,
         sourceDoc: SourceDocument,
         matchingUri?: vscode.Uri
-    ): Promise<RefactorAction[]> {
+    ): Promise<RefactorAction[] | undefined> {
         // FIXME: This function is an absolute mess.
         if (!this.shouldProvideMoveDefinition(rangeOrSelection, context, definition)) {
-            return [];
+            return;
         }
 
         const moveDefinitionToMatchingSourceFile = new RefactorAction(
@@ -428,9 +532,9 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         memberVariable: CSymbol,
         sourceDoc: SourceDocument,
         matchingUri?: vscode.Uri
-    ): Promise<RefactorAction[]> {
+    ): Promise<RefactorAction[] | undefined> {
         if (!this.shouldProvideGetterSetter(rangeOrSelection, context, memberVariable)) {
-            return [];
+            return;
         }
 
         const titleSnippet = ` for "${memberVariable.name}"`;
@@ -468,14 +572,14 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
         context: vscode.CodeActionContext,
         symbol: CSymbol,
         sourceDoc: SourceDocument
-    ): Promise<RefactorAction[]> {
+    ): Promise<RefactorAction[] | undefined> {
         if (!this.shouldProvideClassRefactorings(context, symbol)) {
-            return [];
+            return;
         }
 
         const classSymbol = symbol.isClassType() && !symbol.isAnonymous() ? symbol : symbol.firstNamedParent();
         if (!classSymbol) {
-            return [];
+            return;
         }
         const titleSnippet = ` for "${classSymbol.name}"`;
 
@@ -547,4 +651,28 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
 
         return [addHeaderGuard, addInclude, createMatchingSourceFile];
     }
+}
+
+function declarationRange(symbol: CSymbol): vscode.Range {
+    const maskedText = parse.maskParentheses(symbol.parsableText);
+    const startOffset = symbol.startOffset();
+    const nameEndIndex = symbol.document.offsetAt(symbol.selectionRange.end) - startOffset;
+    const bodyStartIndex = maskedText.substring(nameEndIndex).search(/{|;$/);
+    if (bodyStartIndex === -1) {
+        return new vscode.Range(symbol.declarationStart(), symbol.range.end);
+    }
+
+    if (!symbol.isConstructor()) {
+        return new vscode.Range(
+                symbol.declarationStart(), symbol.document.positionAt(startOffset + nameEndIndex + bodyStartIndex));
+    }
+
+    // Get the start of the constructor's member initializer list, if one is present.
+    const initializerIndex = maskedText.substring(nameEndIndex, bodyStartIndex + nameEndIndex).search(/:(?!:)/);
+    if (initializerIndex === -1) {
+        return new vscode.Range(
+                symbol.declarationStart(), symbol.document.positionAt(startOffset + nameEndIndex + bodyStartIndex));
+    }
+    return new vscode.Range(
+            symbol.declarationStart(), symbol.document.positionAt(startOffset + nameEndIndex + initializerIndex));
 }

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -5,6 +5,7 @@ import CSymbol from './CSymbol';
 
 
 export default class FunctionSignature {
+    name: string;
     returnType: string = '';
     parameters: string[] = [];
     isNoexcept: boolean = false;
@@ -13,7 +14,9 @@ export default class FunctionSignature {
     isConstexpr: boolean = false;
     isConsteval: boolean = false;
 
-    private constructor() { }
+    private constructor(name: string) {
+        this.name = name;
+    }
 
     static parse(symbol: CSymbol): FunctionSignature | undefined {
         if (!symbol.isFunction()) {
@@ -33,7 +36,7 @@ export default class FunctionSignature {
             return;
         }
 
-        const signature = new FunctionSignature();
+        const signature = new FunctionSignature(symbol.name);
 
         signature.parameters = parse.parseParameterTypes(declaration.slice(paramStartIndex, paramEndIndex));
 

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -46,7 +46,7 @@ export default class FunctionSignature {
         }
 
         this.name = functionSymbol.name;
-        this.parameterTypes = parse.parseParameterTypes(declaration.slice(paramStartIndex + 1, paramEndIndex));
+        this.parameterTypes = parse.getParameterTypes(declaration.slice(paramStartIndex + 1, paramEndIndex));
 
         const trailingText = maskedDeclaration.slice(paramEndIndex);
         this.isNoexcept = /\bnoexcept\b/.test(trailingText);
@@ -60,9 +60,7 @@ export default class FunctionSignature {
             this.returnType = trailingReturnMatch[0];
         } else {
             const returnEndIndex = doc.offsetAt(functionSymbol.scopeStringStart()) - declarationStartOffset;
-            const leadingText = declaration.slice(0, returnEndIndex);
-            this.returnType = leadingText.replace(
-                    /\b(virtual|static|explicit|friend|inline|constexpr|consteval)\b\s*/g, '').trim();
+            this.returnType = parse.getLeadingReturnType(declaration.slice(0, returnEndIndex));
         }
     }
 

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -8,6 +8,7 @@ import { ParameterList, parseParameterList } from './ParameterList';
 export type RefQualifier = '' | '&' | '&&';
 
 export default class FunctionSignature {
+    readonly uri: vscode.Uri;
     readonly range: vscode.Range;
     readonly name: string;
     readonly returnType: string;
@@ -45,6 +46,7 @@ export default class FunctionSignature {
         }
 
         const doc = functionSymbol.document;
+        this.uri = doc.uri;
         const declarationStart = functionSymbol.declarationStart();
         const declarationStartOffset = doc.offsetAt(declarationStart);
         const declarationEnd = functionSymbol.declarationEnd();

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -7,6 +7,7 @@ import CSymbol from './CSymbol';
 export type RefQualifier = '' | '&' | '&&';
 
 export default class FunctionSignature {
+    readonly range?: vscode.Range;
     readonly name: string = '';
     readonly returnType: string = '';
     readonly returnTypeRange?: vscode.Range;
@@ -52,7 +53,8 @@ export default class FunctionSignature {
         const declarationStart = functionSymbol.declarationStart();
         const declarationStartOffset = doc.offsetAt(declarationStart);
         const declarationEnd = functionSymbol.declarationEnd();
-        const declaration = doc.getText(new vscode.Range(declarationStart, declarationEnd));
+        this.range = new vscode.Range(declarationStart, declarationEnd);
+        const declaration = doc.getText(this.range);
         const maskedDeclaration = parse.maskParentheses(parse.maskNonSourceText(declaration));
 
         const nameEndIndex = doc.offsetAt(functionSymbol.selectionRange.end) - declarationStartOffset;

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -7,7 +7,7 @@ import CSymbol from './CSymbol';
 export default class FunctionSignature {
     name: string;
     returnType: string = '';
-    parameters: string[] = [];
+    parameterTypes: string[] = [];
     isNoexcept: boolean = false;
     isConst: boolean = false;
     isVolatile: boolean = false;
@@ -38,7 +38,7 @@ export default class FunctionSignature {
 
         const signature = new FunctionSignature(symbol.name);
 
-        signature.parameters = parse.parseParameterTypes(declaration.slice(paramStartIndex, paramEndIndex));
+        signature.parameterTypes = parse.parseParameterTypes(declaration.slice(paramStartIndex, paramEndIndex));
 
         const trailingText = maskedDeclaration.slice(paramEndIndex);
         signature.isNoexcept = /\bnoexcept\b/.test(trailingText);
@@ -61,7 +61,7 @@ export default class FunctionSignature {
     }
 
     equals(other: FunctionSignature): boolean {
-        return util.arraysAreEqual(this.parameters, other.parameters)
+        return util.arraysAreEqual(this.parameterTypes, other.parameterTypes)
             && this.returnType === other.returnType
             && this.isNoexcept === other.isNoexcept
             && this.isConst === other.isConst

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -23,22 +23,16 @@ export default class FunctionSignature {
     readonly noexcept: string;
 
     private _normalizedReturnType: string | undefined;
-    private _normalizedParameterTypes: ReadonlyArray<string> | undefined;
     private _normalizedNoexcept: string | undefined;
 
     get normalizedReturnType(): string {
         return this._normalizedReturnType
-            ?? (this._normalizedReturnType = normalize(this.returnType));
-    }
-
-    get normalizedParameterTypes(): ReadonlyArray<string> {
-        return this._normalizedParameterTypes
-            ?? (this._normalizedParameterTypes = this.parameters.map(parameter => normalize(parameter.type)));
+            ?? (this._normalizedReturnType = parse.normalizeSourceText(this.returnType));
     }
 
     get normalizedNoexcept(): string {
         return this._normalizedNoexcept
-            ?? (this._normalizedNoexcept = normalize(this.noexcept));
+            ?? (this._normalizedNoexcept = parse.normalizeSourceText(this.noexcept));
     }
 
     get hasTrailingReturnType(): boolean {
@@ -122,7 +116,7 @@ export default class FunctionSignature {
     }
 
     equals(other: FunctionSignature): boolean {
-        return util.arraysAreEqual(this.normalizedParameterTypes, other.normalizedParameterTypes)
+        return this.parameters.typesEquals(other.parameters)
             && this.normalizedReturnType === other.normalizedReturnType
             && this.isConstexpr === other.isConstexpr
             && this.isConsteval === other.isConsteval
@@ -141,10 +135,4 @@ function getRefQualifier(maskedTrailingSpecifiers: string): RefQualifier {
     } else {
         return '';
     }
-}
-
-function normalize(sourceText: string): string {
-    sourceText = parse.removeComments(sourceText);
-    sourceText = parse.removeAttributes(sourceText);
-    return parse.normalizeWhitespace(sourceText);
 }

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import * as util from './utility';
+import * as parse from './parsing';
+import CSymbol from './CSymbol';
+
+
+export default class FunctionSignature {
+    returnType: string = '';
+    parameters: string[] = [];
+    isNoexcept: boolean = false;
+    isConst: boolean = false;
+    isVolatile: boolean = false;
+    isConstexpr: boolean = false;
+    isConsteval: boolean = false;
+
+    private constructor() { }
+
+    static parse(symbol: CSymbol): FunctionSignature | undefined {
+        if (!symbol.isFunction()) {
+            return;
+        }
+
+        const doc = symbol.document;
+        const declarationStart = symbol.declarationStart();
+        const declarationStartOffset = doc.offsetAt(declarationStart);
+        const declaration = doc.getText(new vscode.Range(declarationStart, symbol.declarationEnd()));
+        const maskedDeclaration = parse.maskParentheses(parse.maskNonSourceText(declaration));
+
+        const nameEndIndex = doc.offsetAt(symbol.selectionRange.end) - declarationStartOffset;
+        const paramStartIndex = maskedDeclaration.indexOf('(', nameEndIndex) + 1;
+        const paramEndIndex = maskedDeclaration.indexOf(')', nameEndIndex);
+        if (paramStartIndex === -1 || paramEndIndex === -1) {
+            return;
+        }
+
+        const signature = new FunctionSignature();
+
+        signature.parameters = parse.parseParameterTypes(declaration.slice(paramStartIndex, paramEndIndex));
+
+        const trailingText = maskedDeclaration.slice(paramEndIndex);
+        signature.isNoexcept = /\bnoexcept\b/.test(trailingText);
+        signature.isConst = /\bconst\b/.test(trailingText);
+        signature.isVolatile = /\bvolatile\b/.test(trailingText);
+        signature.isConstexpr = symbol.isConstexpr();
+        signature.isConsteval = symbol.isConsteval();
+
+        const trailingReturnMatch = trailingText.match(/(?<=->\s*).+(\s*$)/);
+        if (trailingReturnMatch) {
+            signature.returnType = trailingReturnMatch[0];
+        } else {
+            const returnEndIndex = doc.offsetAt(symbol.scopeStringStart()) - declarationStartOffset;
+            const leadingText = declaration.slice(0, returnEndIndex);
+            signature.returnType = leadingText.replace(
+                    /\b(virtual|static|explicit|friend|inline|constexpr|consteval)\b\s*/g, '').trim();
+        }
+
+        return signature;
+    }
+
+    equals(other: FunctionSignature): boolean {
+        return util.arraysAreEqual(this.parameters, other.parameters)
+            && this.returnType === other.returnType
+            && this.isNoexcept === other.isNoexcept
+            && this.isConst === other.isConst
+            && this.isVolatile === other.isVolatile;
+    }
+}

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -1,30 +1,31 @@
 import * as vscode from 'vscode';
-import * as util from './utility';
 import * as parse from './parsing';
 import CSymbol from './CSymbol';
-import { ParameterList, parseParameterList } from './ParameterList';
+import { ParameterList, Parameter, parseParameterList } from './ParameterList';
 
+
+export { ParameterList, Parameter };
 
 export type RefQualifier = '' | '&' | '&&';
 
 export default class FunctionSignature {
+    readonly name: string;
+    readonly isDefinition: boolean;
     readonly uri: vscode.Uri;
     readonly range: vscode.Range;
-    readonly name: string;
     readonly returnType: string;
     readonly returnTypeRange: vscode.Range;
     readonly parameters: ParameterList;
-    readonly parametersRange: vscode.Range;
-    readonly trailingSpecifierRange: vscode.Range;
     readonly isConstexpr: boolean;
     readonly isConsteval: boolean;
     readonly isConst: boolean;
     readonly isVolatile: boolean;
     readonly refQualifier: RefQualifier;
     readonly noexcept: string;
+    readonly trailingSpecifierRange: vscode.Range;
 
-    private _normalizedReturnType: string | undefined;
-    private _normalizedNoexcept: string | undefined;
+    private _normalizedReturnType?: string;
+    private _normalizedNoexcept?: string;
 
     get normalizedReturnType(): string {
         return this._normalizedReturnType
@@ -37,7 +38,7 @@ export default class FunctionSignature {
     }
 
     get hasTrailingReturnType(): boolean {
-        return this.returnTypeRange.start.isAfter(this.parametersRange.end);
+        return this.returnTypeRange.start.isAfter(this.parameters.range.end);
     }
 
     constructor(functionSymbol: CSymbol) {
@@ -45,42 +46,45 @@ export default class FunctionSignature {
             throw new Error(`FunctionSignature: Cannot construct from non-function symbol "${functionSymbol.name}".`);
         }
 
-        const doc = functionSymbol.document;
-        this.uri = doc.uri;
+        this.name = functionSymbol.name;
+        this.isDefinition = functionSymbol.isFunctionDefinition();
+        this.uri = functionSymbol.uri;
+
+        const sourceDoc = functionSymbol.document;
+
         const declarationStart = functionSymbol.declarationStart();
-        const declarationStartOffset = doc.offsetAt(declarationStart);
+        const declarationStartOffset = sourceDoc.offsetAt(declarationStart);
         const declarationEnd = functionSymbol.declarationEnd();
         this.range = new vscode.Range(declarationStart, declarationEnd);
-        const declaration = doc.getText(this.range);
+
+        const declaration = sourceDoc.getText(this.range);
         const maskedDeclaration = parse.maskParentheses(parse.maskNonSourceText(declaration));
 
-        const nameEndIndex = doc.offsetAt(functionSymbol.selectionRange.end) - declarationStartOffset;
+        const nameEndIndex = sourceDoc.offsetAt(functionSymbol.selectionRange.end) - declarationStartOffset;
         const paramStartIndex = maskedDeclaration.indexOf('(', nameEndIndex);
         const paramEndIndex = maskedDeclaration.indexOf(')', nameEndIndex);
         if (paramStartIndex === -1 || paramEndIndex === -1) {
             throw new Error(`FunctionSignature: Cannot find parameters for function "${functionSymbol.name}".`);
         }
 
-        this.name = functionSymbol.name;
-        const rawParameters = declaration.slice(paramStartIndex + 1, paramEndIndex);
-        const paramStartOffset = declarationStartOffset + paramStartIndex + 1;
-        this.parameters = parseParameterList(rawParameters, paramStartOffset, doc);
-        const parametersStart = doc.positionAt(paramStartOffset);
-        const parametersEnd = doc.positionAt(declarationStartOffset + paramEndIndex);
-        this.parametersRange = new vscode.Range(parametersStart, parametersEnd);
+        const parametersStart = sourceDoc.positionAt(declarationStartOffset + paramStartIndex + 1);
+        const parametersEnd = sourceDoc.positionAt(declarationStartOffset + paramEndIndex);
+        const parametersRange = new vscode.Range(parametersStart, parametersEnd);
+        this.parameters = parseParameterList(sourceDoc, parametersRange);
 
         this.isConstexpr = functionSymbol.isConstexpr();
         this.isConsteval = functionSymbol.isConsteval();
 
+        const trailingSpecifierStart = sourceDoc.positionAt(declarationStartOffset + paramEndIndex + 1);
+        this.trailingSpecifierRange = new vscode.Range(trailingSpecifierStart, declarationEnd);
+
         const trailingText = declaration.slice(paramEndIndex + 1);
         const maskedTrailingText = maskedDeclaration.slice(paramEndIndex + 1);
+
         const noexceptMatch = maskedTrailingText.match(/\bnoexcept\b(\s*\(\s*\))?/);
         this.noexcept = noexceptMatch?.index !== undefined
                 ? trailingText.slice(noexceptMatch.index, noexceptMatch.index + noexceptMatch[0].length)
                 : '';
-
-        const trailingSpecifierStart = doc.positionAt(declarationStartOffset + paramEndIndex + 1);
-        this.trailingSpecifierRange = new vscode.Range(trailingSpecifierStart, declarationEnd);
 
         if (functionSymbol.isConstructor() || functionSymbol.isDestructor()) {
             this.returnType = '';
@@ -91,34 +95,39 @@ export default class FunctionSignature {
             return;
         }
 
-        this.isConst = /\bconst\b/.test(maskedTrailingText);
-        this.isVolatile = /\bvolatile\b/.test(maskedTrailingText);
-
         const trailingReturnMatch = maskedTrailingText.match(/(->\s*)(.+)(?=\s*$)/s);
         if (trailingReturnMatch?.index !== undefined) {
-            this.refQualifier = getRefQualifier(maskedTrailingText.slice(0, trailingReturnMatch.index));
+            const maskedTrailingSpecifiers = maskedTrailingText.slice(0, trailingReturnMatch.index);
+            this.isConst = /\bconst\b/.test(maskedTrailingSpecifiers);
+            this.isVolatile = /\bvolatile\b/.test(maskedTrailingSpecifiers);
+            this.refQualifier = getRefQualifier(maskedTrailingSpecifiers);
+
             const trailingSpecifierEndOffset = declarationStartOffset + paramEndIndex + 1 + trailingReturnMatch.index;
-            const trailingSpecifierEnd = doc.positionAt(trailingSpecifierEndOffset);
+            const trailingSpecifierEnd = sourceDoc.positionAt(trailingSpecifierEndOffset);
             this.trailingSpecifierRange = new vscode.Range(trailingSpecifierStart, trailingSpecifierEnd);
+
             const trailingReturnText = trailingText.slice(trailingReturnMatch.index + trailingReturnMatch[1].length);
             this.returnType = parse.getTrailingReturnType(trailingReturnText);
             const returnStartOffset = trailingSpecifierEndOffset + trailingReturnMatch[1].length;
-            const returnStart = doc.positionAt(returnStartOffset);
-            const returnEnd = doc.positionAt(returnStartOffset + this.returnType.length);
+            const returnStart = sourceDoc.positionAt(returnStartOffset);
+            const returnEnd = sourceDoc.positionAt(returnStartOffset + this.returnType.length);
             this.returnTypeRange = new vscode.Range(returnStart, returnEnd);
         } else {
+            this.isConst = /\bconst\b/.test(maskedTrailingText);
+            this.isVolatile = /\bvolatile\b/.test(maskedTrailingText);
             this.refQualifier = getRefQualifier(maskedTrailingText);
+
             const returnEnd = functionSymbol.scopeStringStart();
-            const returnEndOffset = doc.offsetAt(returnEnd);
+            const returnEndOffset = sourceDoc.offsetAt(returnEnd);
             const returnEndIndex = returnEndOffset - declarationStartOffset;
             this.returnType = parse.getLeadingReturnType(declaration.slice(0, returnEndIndex));
-            const returnStart = doc.positionAt(returnEndOffset - this.returnType.length);
+            const returnStart = sourceDoc.positionAt(returnEndOffset - this.returnType.length);
             this.returnTypeRange = new vscode.Range(returnStart, returnEnd);
         }
     }
 
-    equals(other: FunctionSignature): boolean {
-        return this.parameters.typesEquals(other.parameters)
+    isEqual(other: FunctionSignature): boolean {
+        return this.parameters.typesAreEqual(other.parameters)
             && this.normalizedReturnType === other.normalizedReturnType
             && this.isConstexpr === other.isConstexpr
             && this.isConsteval === other.isConsteval

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -14,6 +14,19 @@ export default class FunctionSignature {
     isConstexpr: boolean = false;
     isConsteval: boolean = false;
 
+    private _normalizedReturnType: string | undefined;
+    private _normalizedParameterTypes: string[] | undefined;
+
+    get normalizedReturnType(): string {
+        return this._normalizedReturnType
+            ?? (this._normalizedReturnType = parse.normalize(this.returnType.trim()));
+    }
+
+    get normalizedParameterTypes(): string[] {
+        return this._normalizedParameterTypes
+            ?? (this._normalizedParameterTypes = this.parameterTypes.map(type => parse.normalize(type.trim())));
+    }
+
     private constructor(name: string) {
         this.name = name;
     }
@@ -61,8 +74,8 @@ export default class FunctionSignature {
     }
 
     equals(other: FunctionSignature): boolean {
-        return util.arraysAreEqual(this.parameterTypes, other.parameterTypes)
-            && this.returnType === other.returnType
+        return util.arraysAreEqual(this.normalizedParameterTypes, other.normalizedParameterTypes)
+            && this.normalizedReturnType === other.normalizedReturnType
             && this.isNoexcept === other.isNoexcept
             && this.isConst === other.isConst
             && this.isVolatile === other.isVolatile;

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -11,6 +11,7 @@ export default class FunctionSignature {
     readonly returnType: string = '';
     readonly returnTypeRange?: vscode.Range;
     readonly parameterTypes: string[] = [];
+    readonly parametersRange?: vscode.Range;
     readonly trailingSpecifierRange?: vscode.Range;
     readonly isConstexpr: boolean = false;
     readonly isConsteval: boolean = false;
@@ -38,6 +39,10 @@ export default class FunctionSignature {
             ?? (this._normalizedNoexcept = parse.normalize(this.noexcept));
     }
 
+    get hasTrailingReturnType(): boolean {
+        return !!this.parametersRange && !!this.returnTypeRange?.start.isAfter(this.parametersRange.end);
+    }
+
     constructor(functionSymbol: CSymbol) {
         if (!functionSymbol.isFunction()) {
             return;
@@ -59,6 +64,9 @@ export default class FunctionSignature {
 
         this.name = functionSymbol.name;
         this.parameterTypes = parse.getParameterTypes(declaration.slice(paramStartIndex + 1, paramEndIndex));
+        const parametersStart = doc.positionAt(declarationStartOffset + paramStartIndex + 1);
+        const parametersEnd = doc.positionAt(declarationStartOffset + paramEndIndex);
+        this.parametersRange = new vscode.Range(parametersStart, parametersEnd);
 
         this.isConstexpr = functionSymbol.isConstexpr();
         this.isConsteval = functionSymbol.isConsteval();

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -60,9 +60,9 @@ export default class FunctionSignature {
         const declaration = sourceDoc.getText(this.range);
         const maskedDeclaration = parse.maskParentheses(parse.maskNonSourceText(declaration));
 
-        const nameEndIndex = sourceDoc.offsetAt(functionSymbol.selectionRange.end) - declarationStartOffset;
-        const paramStartIndex = maskedDeclaration.indexOf('(', nameEndIndex);
-        const paramEndIndex = maskedDeclaration.indexOf(')', nameEndIndex);
+        const nameStartIndex = sourceDoc.offsetAt(functionSymbol.selectionRange.start) - declarationStartOffset;
+        const paramStartIndex = maskedDeclaration.indexOf('(', nameStartIndex);
+        const paramEndIndex = maskedDeclaration.indexOf(')', nameStartIndex);
         if (paramStartIndex === -1 || paramEndIndex === -1) {
             throw new Error(`FunctionSignature: Cannot find parameters for function "${functionSymbol.name}".`);
         }

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -55,6 +55,10 @@ export default class FunctionSignature {
         this.isConstexpr = functionSymbol.isConstexpr();
         this.isConsteval = functionSymbol.isConsteval();
 
+        if (functionSymbol.isConstructor() || functionSymbol.isDestructor()) {
+            return;
+        }
+
         const trailingReturnMatch = trailingText.match(/(?<=->\s*).+(\s*$)/);
         if (trailingReturnMatch) {
             this.returnType = trailingReturnMatch[0];

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -7,13 +7,13 @@ import CSymbol from './CSymbol';
 export type RefQualifier = '' | '&' | '&&';
 
 export default class FunctionSignature {
-    readonly range?: vscode.Range;
+    readonly range: vscode.Range;
     readonly name: string = '';
     readonly returnType: string = '';
-    readonly returnTypeRange?: vscode.Range;
+    readonly returnTypeRange: vscode.Range;
     readonly parameterTypes: string[] = [];
-    readonly parametersRange?: vscode.Range;
-    readonly trailingSpecifierRange?: vscode.Range;
+    readonly parametersRange: vscode.Range;
+    readonly trailingSpecifierRange: vscode.Range;
     readonly isConstexpr: boolean = false;
     readonly isConsteval: boolean = false;
     readonly isConst: boolean = false;
@@ -46,7 +46,7 @@ export default class FunctionSignature {
 
     constructor(functionSymbol: CSymbol) {
         if (!functionSymbol.isFunction()) {
-            return;
+            throw new Error('Cannot construct FunctionSignature from non-function.');
         }
 
         const doc = functionSymbol.document;
@@ -61,7 +61,7 @@ export default class FunctionSignature {
         const paramStartIndex = maskedDeclaration.indexOf('(', nameEndIndex);
         const paramEndIndex = maskedDeclaration.indexOf(')', nameEndIndex);
         if (paramStartIndex === -1 || paramEndIndex === -1) {
-            return;
+            throw new Error('Function parameters not found for FunctionSignature.');
         }
 
         this.name = functionSymbol.name;
@@ -84,6 +84,7 @@ export default class FunctionSignature {
         this.trailingSpecifierRange = new vscode.Range(trailingSpecifierStart, declarationEnd);
 
         if (functionSymbol.isConstructor() || functionSymbol.isDestructor()) {
+            this.returnTypeRange = functionSymbol.selectionRange;
             return;
         }
 

--- a/src/FunctionSignature.ts
+++ b/src/FunctionSignature.ts
@@ -94,7 +94,8 @@ export default class FunctionSignature {
             const trailingSpecifierEndOffset = declarationStartOffset + paramEndIndex + 1 + trailingReturnMatch.index;
             const trailingSpecifierEnd = doc.positionAt(trailingSpecifierEndOffset);
             this.trailingSpecifierRange = new vscode.Range(trailingSpecifierStart, trailingSpecifierEnd);
-            this.returnType = trailingText.slice(trailingReturnMatch.index + trailingReturnMatch[1].length).trimEnd();
+            const trailingReturnText = trailingText.slice(trailingReturnMatch.index + trailingReturnMatch[1].length);
+            this.returnType = parse.getTrailingReturnType(trailingReturnText);
             const returnStartOffset = trailingSpecifierEndOffset + trailingReturnMatch[1].length;
             const returnStart = doc.positionAt(returnStartOffset);
             const returnEnd = doc.positionAt(returnStartOffset + this.returnType.length);

--- a/src/ParameterList.ts
+++ b/src/ParameterList.ts
@@ -33,7 +33,7 @@ export function parseParameterList(document: vscode.TextDocument, range: vscode.
 
     const startOffset = document.offsetAt(range.start);
 
-    const variadicParamStartIndex = maskedParameters.search(/,?\s*...\s*$/);
+    const variadicParamStartIndex = maskedParameters.search(/,?\s*\.\.\.\s*$/);
     if (variadicParamStartIndex !== -1) {
         maskedParameters = maskedParameters.slice(0, variadicParamStartIndex);
     }

--- a/src/ParameterList.ts
+++ b/src/ParameterList.ts
@@ -4,7 +4,7 @@ import * as util from './utility';
 
 
 export interface Parameter {
-    readonly raw: string;
+    readonly text: string;
     readonly type: string;
     readonly normalizedType: string;
     readonly name: string;
@@ -154,7 +154,7 @@ class _Parameter implements Parameter {
     }
 
     constructor(
-        readonly raw: string,
+        readonly text: string,
         readonly type: string,
         readonly name: string,
         readonly defaultValue: string,

--- a/src/ParameterList.ts
+++ b/src/ParameterList.ts
@@ -1,0 +1,94 @@
+import * as vscode from 'vscode';
+import * as parse from './parsing';
+
+
+export interface Parameter {
+    readonly raw: string;
+    readonly type: string;
+    readonly name: string;
+    readonly defaultValue: string;
+    readonly range: vscode.Range;
+}
+
+export type ParameterList = ReadonlyArray<Parameter>;
+
+export function parseParameterList(
+    parameters: string, startOffset: number, document: vscode.TextDocument
+): ParameterList {
+    parameters = parse.maskNonSourceText(parameters, false);
+    // Mask anything that might contain commas or equals-signs.
+    let maskedParameters = parse.maskParentheses(parameters);
+    maskedParameters = parse.maskAngleBrackets(maskedParameters);
+    maskedParameters = parse.maskBraces(maskedParameters);
+    maskedParameters = parse.maskBrackets(maskedParameters);
+    maskedParameters = parse.maskComparisonOperators(maskedParameters);
+
+    const parameterList: Parameter[] = [];
+    for (const match of maskedParameters.matchAll(/(?<=^|,)(\s*)([^,]+)\s*(?=,|$)/g)) {
+        if (match.index !== undefined && !/^\s*$/.test(match[2])) {
+            const index = match.index + match[1].length;
+            const parameter = parameters.slice(index, index + match[2].length);
+            parameterList.push(parseParameter(parameter, match[2], startOffset + index, document));
+        }
+    }
+
+    return parameterList;
+}
+
+function parseParameter(
+    rawParameter: string, maskedParameter: string, startOffset: number, document: vscode.TextDocument
+): Parameter {
+    const defaultValueMatch = maskedParameter.match(/(\s*=\s*)(.+)$/);
+    const defaultValue = defaultValueMatch ? defaultValueMatch[2] : '';
+    const parameter = rawParameter.slice(0, defaultValueMatch?.index);
+    maskedParameter = maskedParameter.slice(0, parameter.length);
+
+    const start = document.positionAt(startOffset);
+    const end = document.positionAt(rawParameter.length + startOffset);
+    const range = new vscode.Range(start, end);
+
+    const nameMatch = maskedParameter.match(/(?<=.+)(\b[\w_][\w\d_]*)(\s*\[\s*\])*$/s);
+    if (nameMatch) {
+        const parameterType = parameter.slice(0, -nameMatch[0].length).trim();
+        if (parameterType.length !== 0 && nameMatch[1] !== 'const' && nameMatch[1] !== 'volatile'
+                && !/^(const|volatile)(\s+(const|volatile))?\s*$/.test(parameterType)) {
+            return {
+                raw: rawParameter.trim(),
+                type: parameterType + (nameMatch[2] ? parameter.slice(-nameMatch[2].length) : ''),
+                name: nameMatch[1],
+                defaultValue: defaultValue,
+                range: range
+            };
+        }
+    } else {
+        const nestedDeclaratorIndex = maskedParameter.search(/\(\s*\)(\s*\(\s*\)|(\s*\[\s*\])+)$/);
+        if (nestedDeclaratorIndex !== -1) {
+            const deepestRightParen = parameter.indexOf(')', nestedDeclaratorIndex);
+            if (deepestRightParen !== -1) {
+                const trimmedParameter = parameter.slice(0, deepestRightParen);
+                const nestedNameMatch = trimmedParameter.match(/\b[\w_][\w\d_]*(?=\s*$)/);
+                if (nestedNameMatch?.index !== undefined
+                        && nestedNameMatch[0] !== 'const' && nestedNameMatch[0] !== 'volatile') {
+                    const parameterType = trimmedParameter.slice(0, nestedNameMatch.index)
+                            + trimmedParameter.slice(nestedNameMatch.index + nestedNameMatch[0].length)
+                            + parameter.slice(deepestRightParen);
+                    return {
+                        raw: rawParameter.trim(),
+                        type: parameterType.trim(),
+                        name: nestedNameMatch[0],
+                        defaultValue: defaultValue,
+                        range: range
+                    };
+                }
+            }
+        }
+    }
+
+    return {
+        raw: rawParameter.trim(),
+        type: parameter.trim(),
+        name: '',
+        defaultValue: defaultValue,
+        range: range
+    };
+}

--- a/src/ProposedPosition.ts
+++ b/src/ProposedPosition.ts
@@ -21,11 +21,7 @@ export class ProposedPosition extends Position {
             super(0, 0);
         }
 
-        if (options) {
-            this.options = options;
-        } else {
-            this.options = { };
-        }
+        this.options = options ?? { };
     }
 
     formatTextToInsert(insertText: string, sourceDoc: SourceDocument): string {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,6 +3,7 @@ import {
     addDefinitionInSourceFile, addDefinitionInCurrentFile, addDefinitions, addDefinition
 } from './addDefinition';
 import { addDeclaration } from './addDeclaration';
+import { updateSignature } from './updateSignature';
 import { moveDefinitionToMatchingSourceFile, moveDefinitionIntoOrOutOfClass } from './moveDefinition';
 import {
     generateGetterSetter, generateGetter, generateSetter,
@@ -24,6 +25,7 @@ export type CmanticCommandId =
     | 'cmantic.addDefinitions'
     | 'cmantic.addDefinition'
     | 'cmantic.addDeclaration'
+    | 'cmantic.updateSignature'
     | 'cmantic.moveDefinitionToMatchingSourceFile'
     | 'cmantic.moveDefinitionIntoOrOutOfClass'
     | 'cmantic.generateGetterSetter'
@@ -55,6 +57,7 @@ export const commandHandlers: CommandHandlerMap = {
     'cmantic.addDefinitions': addDefinitions,
     'cmantic.addDefinition': addDefinition,
     'cmantic.addDeclaration': addDeclaration,
+    'cmantic.updateSignature': updateSignature,
     'cmantic.moveDefinitionToMatchingSourceFile': moveDefinitionToMatchingSourceFile,
     'cmantic.moveDefinitionIntoOrOutOfClass': moveDefinitionIntoOrOutOfClass,
     'cmantic.generateGetterSetter': generateGetterSetter,

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import SourceDocument from '../SourceDocument';
 import CSymbol from '../CSymbol';
+import FunctionSignature from '../FunctionSignature';
+import { logger } from '../extension';
 
 
 export async function updateSignature(
@@ -8,5 +10,26 @@ export async function updateSignature(
     sourceDoc: SourceDocument,
     linkedLocation: vscode.Location
 ): Promise<boolean | undefined> {
-    return;
+    const linkedDoc = linkedLocation.uri.fsPath === sourceDoc.uri.fsPath
+            ? sourceDoc
+            : await SourceDocument.open(linkedLocation.uri);
+    const linkedSymbol = await linkedDoc.getSymbol(linkedLocation.range.start);
+
+    if (functionSymbol.isFunctionDeclaration()) {
+        if (!linkedSymbol?.isFunctionDefinition() || linkedSymbol.name !== functionSymbol.name) {
+            logger.alertError('The linked definition could not be found.');
+            return;
+        }
+
+        const currentSignature = FunctionSignature.parse(functionSymbol);
+        const linkedSignature = FunctionSignature.parse(linkedSymbol);
+    } else {
+        if (!linkedSymbol?.isFunctionDeclaration() || linkedSymbol.name !== functionSymbol.name) {
+            logger.alertError('The linked declaration could not be found.');
+            return;
+        }
+
+        const currentSignature = FunctionSignature.parse(functionSymbol);
+        const linkedSignature = FunctionSignature.parse(linkedSymbol);
+    }
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -48,10 +48,10 @@ function updateReturnType(
     if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
         const nextCharEnd = linkedSignature.returnTypeRange.end.translate(0, 1);
         const nextChar = linkedDoc.getText(new vscode.Range(linkedSignature.returnTypeRange.end, nextCharEnd));
-        const returnType = /[\w\d_]$/.test(currentSignature.returnType) && /^[\w\d_]$/.test(nextChar)
+        const newReturnType = /[\w\d_]$/.test(currentSignature.returnType) && /^[\w\d_]$/.test(nextChar)
                 ? currentSignature.returnType + ' '
                 : currentSignature.returnType;
-        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange, returnType);
+        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange, newReturnType);
     }
 }
 

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -28,59 +28,138 @@ export async function updateSignature(
         }
     }
 
-    const currentSignature = new FunctionSignature(currentFunction);
-    const linkedSignature = new FunctionSignature(linkedFunction);
+    const currentSig = new FunctionSignature(currentFunction);
+    const linkedSig = new FunctionSignature(linkedFunction);
 
     const workspaceEdit = new vscode.WorkspaceEdit();
 
-    updateReturnType(currentSignature, linkedSignature, linkedDoc, workspaceEdit);
-    updateSpecifiers(currentSignature, linkedSignature, linkedDoc, workspaceEdit);
+    updateReturnType(currentSig, linkedSig, linkedDoc, workspaceEdit);
+    updateParameters(currentSig, linkedSig, linkedDoc, workspaceEdit);
+    updateSpecifiers(currentSig, linkedSig, linkedDoc, workspaceEdit);
 
     return vscode.workspace.applyEdit(workspaceEdit);
 }
 
 function updateReturnType(
-    currentSignature: FunctionSignature,
-    linkedSignature: FunctionSignature,
+    currentSig: FunctionSignature,
+    linkedSig: FunctionSignature,
     linkedDoc: SourceDocument,
     workspaceEdit: vscode.WorkspaceEdit
 ): void {
-    if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
-        const nextCharEnd = linkedSignature.returnTypeRange.end.translate(0, 1);
-        const nextChar = linkedDoc.getText(new vscode.Range(linkedSignature.returnTypeRange.end, nextCharEnd));
-        const newReturnType = /[\w\d_]$/.test(currentSignature.returnType) && /^[\w\d_]$/.test(nextChar)
-                ? currentSignature.returnType + ' '
-                : currentSignature.returnType;
-        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange, newReturnType);
+    if (currentSig.normalizedReturnType !== linkedSig.normalizedReturnType) {
+        const nextCharEnd = linkedSig.returnTypeRange.end.translate(0, 1);
+        const nextChar = linkedDoc.getText(new vscode.Range(linkedSig.returnTypeRange.end, nextCharEnd));
+        const newReturnType = /[\w\d_]$/.test(currentSig.returnType) && /^[\w\d_]/.test(nextChar)
+                ? currentSig.returnType + ' '
+                : currentSig.returnType;
+        workspaceEdit.replace(linkedDoc.uri, linkedSig.returnTypeRange, newReturnType);
+    }
+}
+
+function updateParameters(
+    currentSig: FunctionSignature,
+    linkedSig: FunctionSignature,
+    linkedDoc: SourceDocument,
+    workspaceEdit: vscode.WorkspaceEdit
+): void {
+    if (currentSig.parameters.typesEquals(linkedSig.parameters)) {
+        return;
     }
 }
 
 function updateSpecifiers(
-    currentSignature: FunctionSignature,
-    linkedSignature: FunctionSignature,
+    currentSig: FunctionSignature,
+    linkedSig: FunctionSignature,
     linkedDoc: SourceDocument,
     workspaceEdit: vscode.WorkspaceEdit
 ): void {
-    const declaration = parse.maskComments(linkedDoc.getText(linkedSignature.range), true);
-    const startOffset = linkedDoc.offsetAt(linkedSignature.range.start);
+    const declaration = parse.maskComments(linkedDoc.getText(linkedSig.range), true);
+    const startOffset = linkedDoc.offsetAt(linkedSig.range.start);
 
     function removeLeadingSpecifier(re_specifier: RegExp): void {
         const match = declaration.match(re_specifier);
         if (match?.index !== undefined) {
-            const range = linkedDoc.rangeAt(startOffset + match.index, startOffset + match.index + match[0].length);
+            const matchOffset = startOffset + match.index;
+            const range = linkedDoc.rangeAt(matchOffset, matchOffset + match[0].length);
             workspaceEdit.replace(linkedDoc.uri, range, '');
         }
     }
 
-    if (currentSignature.isConstexpr && !linkedSignature.isConstexpr) {
-        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range.start, 'constexpr ');
-    } else if (!currentSignature.isConstexpr && linkedSignature.isConstexpr) {
+    if (currentSig.isConstexpr && !linkedSig.isConstexpr) {
+        workspaceEdit.insert(linkedDoc.uri, linkedSig.range.start, 'constexpr ');
+    } else if (!currentSig.isConstexpr && linkedSig.isConstexpr) {
         removeLeadingSpecifier(/\bconstexpr\b[ \t]*/);
     }
 
-    if (currentSignature.isConsteval && !linkedSignature.isConsteval) {
-        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range.start, 'consteval ');
-    } else if (!currentSignature.isConsteval && linkedSignature.isConsteval) {
+    if (currentSig.isConsteval && !linkedSig.isConsteval) {
+        workspaceEdit.insert(linkedDoc.uri, linkedSig.range.start, 'consteval ');
+    } else if (!currentSig.isConsteval && linkedSig.isConsteval) {
         removeLeadingSpecifier(/\bconsteval\b[ \t]*/);
     }
+
+    let trailingSpecifiers = linkedDoc.getText(linkedSig.trailingSpecifierRange);
+    let maskedSpecifiers = parse.maskComments(trailingSpecifiers, true);
+    maskedSpecifiers = parse.maskRawStringLiterals(maskedSpecifiers, true);
+    maskedSpecifiers = parse.maskQuotes(maskedSpecifiers, true);
+    maskedSpecifiers = parse.maskAttributes(maskedSpecifiers, true);
+    maskedSpecifiers = parse.maskParentheses(maskedSpecifiers, true);
+
+    if (currentSig.isConst && !linkedSig.isConst) {
+        const specifier = /^[\w\d_]/.test(trailingSpecifiers) ? ' const ' : ' const';
+        trailingSpecifiers = specifier + trailingSpecifiers;
+        maskedSpecifiers = specifier + maskedSpecifiers;
+    } else if (!currentSig.isConst && linkedSig.isConst) {
+        const match = maskedSpecifiers.match(/(?<!\n)[ \t]*\bconst\b/);
+        if (match?.index !== undefined) {
+            trailingSpecifiers = trailingSpecifiers.slice(0, match.index)
+                    + trailingSpecifiers.slice(match.index + match[0].length);
+            maskedSpecifiers = maskedSpecifiers.slice(0, match.index)
+                    + maskedSpecifiers.slice(match.index + match[0].length);
+        }
+    }
+
+    if (currentSig.isVolatile && !linkedSig.isVolatile) {
+        const specifier = /^[\w\d_]/.test(trailingSpecifiers) ? ' volatile ' : ' volatile';
+        trailingSpecifiers = specifier + trailingSpecifiers;
+        maskedSpecifiers = specifier + maskedSpecifiers;
+    } else if (!currentSig.isVolatile && linkedSig.isVolatile) {
+        const match = maskedSpecifiers.match(/(?<!\n)[ \t]*\bvolatile\b/);
+        if (match?.index !== undefined) {
+            trailingSpecifiers = trailingSpecifiers.slice(0, match.index)
+                    + trailingSpecifiers.slice(match.index + match[0].length);
+            maskedSpecifiers = maskedSpecifiers.slice(0, match.index)
+                    + maskedSpecifiers.slice(match.index + match[0].length);
+        }
+    }
+
+    if (currentSig.refQualifier !== linkedSig.refQualifier) {
+        if (linkedSig.refQualifier.length !== 0) {
+            trailingSpecifiers = trailingSpecifiers.replace(linkedSig.refQualifier, currentSig.refQualifier);
+            maskedSpecifiers = maskedSpecifiers.replace(linkedSig.refQualifier, currentSig.refQualifier);
+        } else {
+            const match = maskedSpecifiers.match(/^[\s\/\*]*(const|volatile)([\s\/\*]*(const|volatile))?/);
+            if (match) {
+                trailingSpecifiers = trailingSpecifiers.slice(0, match[0].length)
+                        + ' ' + currentSig.refQualifier + trailingSpecifiers.slice(match[0].length);
+                maskedSpecifiers = match[0] + ' ' + currentSig.refQualifier + maskedSpecifiers.slice(match[0].length);
+            } else {
+                trailingSpecifiers = ' ' + currentSig.refQualifier + trailingSpecifiers;
+                maskedSpecifiers = ' ' + currentSig.refQualifier + maskedSpecifiers;
+            }
+        }
+    }
+
+    if (currentSig.normalizedNoexcept !== linkedSig.normalizedNoexcept) {
+        if (linkedSig.normalizedNoexcept.length === 0) {
+            trailingSpecifiers += currentSig.noexcept;
+        } else {
+            const match = maskedSpecifiers.match(/(?<!\n)([ \t]*)\bnoexcept\b(\s*\(\s*\))?/);
+            if (match?.index !== undefined) {
+                trailingSpecifiers = trailingSpecifiers.slice(0, match.index + match[1].length)
+                        + currentSig.noexcept + trailingSpecifiers.slice(match.index + match[0].length);
+            }
+        }
+    }
+
+    workspaceEdit.replace(linkedDoc.uri, linkedSig.trailingSpecifierRange, trailingSpecifiers);
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -82,7 +82,7 @@ function updateParameters(
         });
 
         let parametersText = '';
-        if (currentSig.parameters.range.start.line !== currentSig.parameters.range.end.line) {
+        if (!currentSig.parameters.range.isSingleLine) {
             const diff = linkedSig.parameters.range.start.character - currentSig.parameters.range.start.character;
             const eol = linkedDoc.endOfLine;
             let lastPos: vscode.Position | undefined;
@@ -110,7 +110,7 @@ function updateParameters(
             ? parse.stripDefaultValues(sourceDoc.getText(currentSig.parameters.range))
             : sourceDoc.getText(currentSig.parameters.range);
 
-    if (currentSig.parameters.range.start.line !== currentSig.parameters.range.end.line) {
+    if (!currentSig.parameters.range.isSingleLine) {
         const diff = linkedSig.parameters.range.start.character - currentSig.parameters.range.start.character;
         if (diff > 0) {
             parametersText = parametersText.replace(/\n/g, '\n' + ' '.repeat(diff));

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -8,6 +8,7 @@ import { logger } from '../extension';
 
 export async function updateSignature(
     currentFunction: CSymbol,
+    previousSig: FunctionSignature,
     sourceDoc: SourceDocument,
     linkedLocation: vscode.Location
 ): Promise<boolean | undefined> {
@@ -34,7 +35,7 @@ export async function updateSignature(
     const workspaceEdit = new vscode.WorkspaceEdit();
 
     updateReturnType(currentSig, linkedSig, linkedDoc, workspaceEdit);
-    updateParameters(currentSig, linkedSig, linkedDoc, workspaceEdit);
+    updateParameters(currentSig, previousSig, linkedSig, linkedDoc, workspaceEdit);
     updateSpecifiers(currentSig, linkedSig, linkedDoc, workspaceEdit);
 
     return vscode.workspace.applyEdit(workspaceEdit);
@@ -58,11 +59,12 @@ function updateReturnType(
 
 function updateParameters(
     currentSig: FunctionSignature,
+    previousSig: FunctionSignature,
     linkedSig: FunctionSignature,
     linkedDoc: SourceDocument,
     workspaceEdit: vscode.WorkspaceEdit
 ): void {
-    if (currentSig.parameters.typesEquals(linkedSig.parameters)) {
+    if (currentSig.parameters.typesAreEqual(previousSig.parameters)) {
         return;
     }
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+import SourceDocument from '../SourceDocument';
+import CSymbol from '../CSymbol';
+
+
+export async function updateSignature(
+    functionSymbol: CSymbol,
+    sourceDoc: SourceDocument,
+    linkedLocation: vscode.Location
+): Promise<boolean | undefined> {
+    return;
+}

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -46,9 +46,11 @@ function updateReturnType(
     workspaceEdit: vscode.WorkspaceEdit
 ): void {
     if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
-        const returnType = !linkedSignature.hasTrailingReturnType && /[\w\d_]$/.test(linkedSignature.returnType)
-                ? linkedSignature.returnType + ' '
-                : linkedSignature.returnType;
+        const nextCharEnd = linkedSignature.returnTypeRange.end.translate(0, 1);
+        const nextChar = linkedDoc.getText(new vscode.Range(linkedSignature.returnTypeRange.end, nextCharEnd));
+        const returnType = /[\w\d_]$/.test(currentSignature.returnType) && /^[\w\d_]$/.test(nextChar)
+                ? currentSignature.returnType + ' '
+                : currentSignature.returnType;
         workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange, returnType);
     }
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -32,9 +32,22 @@ export async function updateSignature(
 
     const workspaceEdit = new vscode.WorkspaceEdit();
 
-    if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
-        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange!, currentSignature.returnType);
-    }
+    updateReturnType(currentSignature, linkedSignature, linkedDoc.uri, workspaceEdit);
 
     return vscode.workspace.applyEdit(workspaceEdit);
 }
+
+function updateReturnType(
+    currentSignature: FunctionSignature,
+    linkedSignature: FunctionSignature,
+    linkedUri: vscode.Uri,
+    workspaceEdit: vscode.WorkspaceEdit
+): void {
+    if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
+        const returnType = !linkedSignature.hasTrailingReturnType && /[\w\d_]$/.test(linkedSignature.returnType)
+                ? linkedSignature.returnType + ' '
+                : linkedSignature.returnType;
+        workspaceEdit.replace(linkedUri, linkedSignature.returnTypeRange!, returnType);
+    }
+}
+

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -49,7 +49,7 @@ function updateReturnType(
         const returnType = !linkedSignature.hasTrailingReturnType && /[\w\d_]$/.test(linkedSignature.returnType)
                 ? linkedSignature.returnType + ' '
                 : linkedSignature.returnType;
-        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange!, returnType);
+        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange, returnType);
     }
 }
 
@@ -60,7 +60,7 @@ function updateSpecifiers(
     workspaceEdit: vscode.WorkspaceEdit
 ): void {
     const declaration = parse.maskComments(linkedDoc.getText(linkedSignature.range), true);
-    const startOffset = linkedDoc.offsetAt(linkedSignature.range!.start);
+    const startOffset = linkedDoc.offsetAt(linkedSignature.range.start);
 
     function removeLeadingSpecifier(re_specifier: RegExp): void {
         const match = declaration.match(re_specifier);
@@ -71,13 +71,13 @@ function updateSpecifiers(
     }
 
     if (currentSignature.isConstexpr && !linkedSignature.isConstexpr) {
-        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range!.start, 'constexpr ');
+        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range.start, 'constexpr ');
     } else if (!currentSignature.isConstexpr && linkedSignature.isConstexpr) {
         removeLeadingSpecifier(/\bconstexpr\b[ \t]*/);
     }
 
     if (currentSignature.isConsteval && !linkedSignature.isConsteval) {
-        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range!.start, 'consteval ');
+        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range.start, 'consteval ');
     } else if (!currentSignature.isConsteval && linkedSignature.isConsteval) {
         removeLeadingSpecifier(/\bconsteval\b[ \t]*/);
     }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -6,30 +6,30 @@ import { logger } from '../extension';
 
 
 export async function updateSignature(
-    functionSymbol: CSymbol,
+    currentFunction: CSymbol,
     sourceDoc: SourceDocument,
     linkedLocation: vscode.Location
 ): Promise<boolean | undefined> {
     const linkedDoc = linkedLocation.uri.fsPath === sourceDoc.uri.fsPath
             ? sourceDoc
             : await SourceDocument.open(linkedLocation.uri);
-    const linkedSymbol = await linkedDoc.getSymbol(linkedLocation.range.start);
+    const linkedFunction = await linkedDoc.getSymbol(linkedLocation.range.start);
 
-    if (functionSymbol.isFunctionDeclaration()) {
-        if (!linkedSymbol?.isFunctionDefinition() || linkedSymbol.name !== functionSymbol.name) {
+    if (currentFunction.isFunctionDeclaration()) {
+        if (!linkedFunction?.isFunctionDefinition() || linkedFunction.name !== currentFunction.name) {
             logger.alertError('The linked definition could not be found.');
             return;
         }
 
-        const currentSignature = new FunctionSignature(functionSymbol);
-        const linkedSignature = new FunctionSignature(linkedSymbol);
+        const currentSignature = new FunctionSignature(currentFunction);
+        const linkedSignature = new FunctionSignature(linkedFunction);
     } else {
-        if (!linkedSymbol?.isFunctionDeclaration() || linkedSymbol.name !== functionSymbol.name) {
+        if (!linkedFunction?.isFunctionDeclaration() || linkedFunction.name !== currentFunction.name) {
             logger.alertError('The linked declaration could not be found.');
             return;
         }
 
-        const currentSignature = new FunctionSignature(functionSymbol);
-        const linkedSignature = new FunctionSignature(linkedSymbol);
+        const currentSignature = new FunctionSignature(currentFunction);
+        const linkedSignature = new FunctionSignature(linkedFunction);
     }
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -20,16 +20,21 @@ export async function updateSignature(
             logger.alertError('The linked definition could not be found.');
             return;
         }
-
-        const currentSignature = new FunctionSignature(currentFunction);
-        const linkedSignature = new FunctionSignature(linkedFunction);
     } else {
         if (!linkedFunction?.isFunctionDeclaration() || linkedFunction.name !== currentFunction.name) {
             logger.alertError('The linked declaration could not be found.');
             return;
         }
-
-        const currentSignature = new FunctionSignature(currentFunction);
-        const linkedSignature = new FunctionSignature(linkedFunction);
     }
+
+    const currentSignature = new FunctionSignature(currentFunction);
+    const linkedSignature = new FunctionSignature(linkedFunction);
+
+    const workspaceEdit = new vscode.WorkspaceEdit();
+
+    if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
+        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange!, currentSignature.returnType);
+    }
+
+    return vscode.workspace.applyEdit(workspaceEdit);
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as parse from '../parsing';
 import SourceDocument from '../SourceDocument';
 import CSymbol from '../CSymbol';
 import FunctionSignature from '../FunctionSignature';
@@ -32,7 +33,8 @@ export async function updateSignature(
 
     const workspaceEdit = new vscode.WorkspaceEdit();
 
-    updateReturnType(currentSignature, linkedSignature, linkedDoc.uri, workspaceEdit);
+    updateReturnType(currentSignature, linkedSignature, linkedDoc, workspaceEdit);
+    updateSpecifiers(currentSignature, linkedSignature, linkedDoc, workspaceEdit);
 
     return vscode.workspace.applyEdit(workspaceEdit);
 }
@@ -40,14 +42,43 @@ export async function updateSignature(
 function updateReturnType(
     currentSignature: FunctionSignature,
     linkedSignature: FunctionSignature,
-    linkedUri: vscode.Uri,
+    linkedDoc: SourceDocument,
     workspaceEdit: vscode.WorkspaceEdit
 ): void {
     if (currentSignature.normalizedReturnType !== linkedSignature.normalizedReturnType) {
         const returnType = !linkedSignature.hasTrailingReturnType && /[\w\d_]$/.test(linkedSignature.returnType)
                 ? linkedSignature.returnType + ' '
                 : linkedSignature.returnType;
-        workspaceEdit.replace(linkedUri, linkedSignature.returnTypeRange!, returnType);
+        workspaceEdit.replace(linkedDoc.uri, linkedSignature.returnTypeRange!, returnType);
     }
 }
 
+function updateSpecifiers(
+    currentSignature: FunctionSignature,
+    linkedSignature: FunctionSignature,
+    linkedDoc: SourceDocument,
+    workspaceEdit: vscode.WorkspaceEdit
+): void {
+    const declaration = parse.maskComments(linkedDoc.getText(linkedSignature.range), true);
+    const startOffset = linkedDoc.offsetAt(linkedSignature.range!.start);
+
+    function removeLeadingSpecifier(re_specifier: RegExp): void {
+        const match = declaration.match(re_specifier);
+        if (match?.index !== undefined) {
+            const range = linkedDoc.rangeAt(startOffset + match.index, startOffset + match.index + match[0].length);
+            workspaceEdit.replace(linkedDoc.uri, range, '');
+        }
+    }
+
+    if (currentSignature.isConstexpr && !linkedSignature.isConstexpr) {
+        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range!.start, 'constexpr ');
+    } else if (!currentSignature.isConstexpr && linkedSignature.isConstexpr) {
+        removeLeadingSpecifier(/\bconstexpr\b[ \t]*/);
+    }
+
+    if (currentSignature.isConsteval && !linkedSignature.isConsteval) {
+        workspaceEdit.insert(linkedDoc.uri, linkedSignature.range!.start, 'consteval ');
+    } else if (!currentSignature.isConsteval && linkedSignature.isConsteval) {
+        removeLeadingSpecifier(/\bconsteval\b[ \t]*/);
+    }
+}

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -21,15 +21,15 @@ export async function updateSignature(
             return;
         }
 
-        const currentSignature = FunctionSignature.parse(functionSymbol);
-        const linkedSignature = FunctionSignature.parse(linkedSymbol);
+        const currentSignature = new FunctionSignature(functionSymbol);
+        const linkedSignature = new FunctionSignature(linkedSymbol);
     } else {
         if (!linkedSymbol?.isFunctionDeclaration() || linkedSymbol.name !== functionSymbol.name) {
             logger.alertError('The linked declaration could not be found.');
             return;
         }
 
-        const currentSignature = FunctionSignature.parse(functionSymbol);
-        const linkedSignature = FunctionSignature.parse(linkedSymbol);
+        const currentSignature = new FunctionSignature(functionSymbol);
+        const linkedSignature = new FunctionSignature(linkedSymbol);
     }
 }

--- a/src/commands/updateSignature.ts
+++ b/src/commands/updateSignature.ts
@@ -50,7 +50,7 @@ function updateReturnType(
     if (currentSig.normalizedReturnType !== linkedSig.normalizedReturnType) {
         const nextCharEnd = linkedSig.returnTypeRange.end.translate(0, 1);
         const nextChar = linkedDoc.getText(new vscode.Range(linkedSig.returnTypeRange.end, nextCharEnd));
-        const newReturnType = /[\w\d_]$/.test(currentSig.returnType) && /^[\w\d_]/.test(nextChar)
+        const newReturnType = /^[\w\d_]/.test(nextChar) && /[\w\d_][^\w\d_\s]*$/.test(currentSig.returnType)
                 ? currentSig.returnType + ' '
                 : currentSig.returnType;
         workspaceEdit.replace(linkedDoc.uri, linkedSig.returnTypeRange, newReturnType);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,9 +12,9 @@ export const cmanticId = 'tdennis4496.cmantic';
 
 export const logger = new Logger('C-mantic');
 
-const disposables: vscode.Disposable[] = [logger];
 const codeActionProvider = new CodeActionProvider();
 const headerSourceCache = new HeaderSourceCache();
+const disposables: vscode.Disposable[] = [logger, codeActionProvider];
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     registerCommands(context);
@@ -112,13 +112,6 @@ async function onDidCreateFiles(event: vscode.FileCreateEvent): Promise<void> {
 }
 
 function onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent): void {
-    if (event.affectsConfiguration(cfg.extensionKey)) {
-        codeActionProvider.addDefinitionEnabled = cfg.enableAddDefinition();
-        codeActionProvider.addDeclarationEnabled = cfg.enableAddDeclaration();
-        codeActionProvider.moveDefinitionEnabled = cfg.enableMoveDefinition();
-        codeActionProvider.generateGetterSetterEnabled = cfg.enableGenerateGetterSetter();
-    }
-
     if (event.affectsConfiguration(cfg.cpptoolsKey)) {
         setActiveLanguageServer();
     }

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -142,6 +142,12 @@ export function normalizeWhitespace(text: string): string {
     return text.replace(/\b\s+\B|\B\s+\b|\B\s+\B/g, '').replace(/\s+/g, ' ');
 }
 
+export function normalizeSourceText(sourceText: string): string {
+    sourceText = removeComments(sourceText);
+    sourceText = removeAttributes(sourceText);
+    return normalizeWhitespace(sourceText);
+}
+
 /**
  * DocumentSymbol.range doesn't always include the final semi-colon, so this finds the end of the last semi-colon.
  */

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -256,6 +256,22 @@ export function getLeadingReturnType(leadingText: string): string {
     return leadingText.slice(startOfType);
 }
 
+const re_constVolatileRefPtr = /^(const|volatile|&{1,2}|\*{1,})$/;
+
+export function getTrailingReturnType(trailingText: string): string {
+    const maskedTrailingText = maskAngleBrackets(maskNonSourceText(trailingText));
+
+    let endOfType: number | undefined;
+    for (const match of maskedTrailingText.matchAll(/\b[\w_][\w\d_]*\b(\s*::\s*[\w_][\w\d_]*\b)*|&{1,2}|\*{1,}/g)) {
+        if ((endOfType === undefined && !re_constVolatileRefPtr.test(match[0]))
+                || (endOfType !== undefined && re_constVolatileRefPtr.test(match[0]))) {
+            endOfType = match.index !== undefined ? match.index + match[0].length : undefined;
+        }
+    }
+
+    return trailingText.slice(0, endOfType);
+}
+
 const re_primitiveTypes =
         /\b(void|bool|char|wchar_t|char8_t|char16_t|char32_t|int|short|long|signed|unsigned|float|double)\b/;
 

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -214,8 +214,8 @@ export function getParameterTypes(parameters: string): string[] {
     const maskedParameters = maskParameters(parameters);
 
     const parameterTypes: string[] = [];
-    for (const match of maskedParameters.matchAll(/(?<=^|,)[^=,]*(?==|,|$)/g)) {
-        if (match.index !== undefined) {
+    for (const match of maskedParameters.matchAll(/(?<=^|,)[^=,]+(?==|,|$)/g)) {
+        if (match.index !== undefined && match[0].trim().length !== 0) {
             const parameter = parameters.slice(match.index, match.index + match[0].length).trim();
             const nameMatch = parameter.match(/(?<=.+)\b[\w_][\w\d_]*$/);
             if (nameMatch) {

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -256,13 +256,15 @@ export function getLeadingReturnType(leadingText: string): string {
     return leadingText.slice(startOfType);
 }
 
+const re_trailingReturnTypeFragments =
+        /\b[\w_][\w\d_]*\b(\s*::\s*[\w_][\w\d_]*\b)*(\s*<\s*>)?(\s*\(\s*\)){0,2}|&{1,2}|\*{1,}/g;
 const re_constVolatileRefPtr = /^(const|volatile|&{1,2}|\*{1,})$/;
 
 export function getTrailingReturnType(trailingText: string): string {
-    const maskedTrailingText = maskAngleBrackets(maskNonSourceText(trailingText));
+    const maskedTrailingText = maskAngleBrackets(maskParentheses(maskNonSourceText(trailingText)));
 
     let endOfType: number | undefined;
-    for (const match of maskedTrailingText.matchAll(/\b[\w_][\w\d_]*\b(\s*::\s*[\w_][\w\d_]*\b)*|&{1,2}|\*{1,}/g)) {
+    for (const match of maskedTrailingText.matchAll(re_trailingReturnTypeFragments)) {
         if ((endOfType === undefined && !re_constVolatileRefPtr.test(match[0]))
                 || (endOfType !== undefined && re_constVolatileRefPtr.test(match[0]))) {
             endOfType = match.index !== undefined ? match.index + match[0].length : undefined;

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -210,7 +210,7 @@ export function stripDefaultValues(parameters: string): string {
     return strippedParameters.slice(0, -1);
 }
 
-export function parseParameterTypes(parameters: string): string[] {
+export function getParameterTypes(parameters: string): string[] {
     const maskedParameters = maskParameters(parameters);
 
     const parameterTypes: string[] = [];
@@ -233,6 +233,27 @@ export function parseParameterTypes(parameters: string): string[] {
     }
 
     return parameterTypes;
+}
+
+export function getLeadingReturnType(leadingText: string): string {
+    const maskedLeadingText = maskAngleBrackets(maskNonSourceText(leadingText));
+
+    const identifierMatches: RegExpMatchArray[] = [];
+    for (const match of maskedLeadingText.matchAll(/\b[\w_][\w\d_]*\b(\s*::\s*[\w_][\w\d_]*\b)*/g)) {
+        identifierMatches.push(match);
+    }
+
+    let startOfType: number | undefined;
+    for (let i = identifierMatches.length - 1; i >= 0; --i) {
+        if ((startOfType === undefined
+                && identifierMatches[i][0] !== 'const' && identifierMatches[i][0] !== 'volatile')
+            || (startOfType !== undefined
+                && (identifierMatches[i][0] === 'const' || identifierMatches[i][0] === 'volatile'))) {
+            startOfType = identifierMatches[i].index;
+        }
+    }
+
+    return leadingText.slice(startOfType);
 }
 
 const re_primitiveTypes =

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -135,8 +135,8 @@ export function maskComparisonOperators(text: string): string {
 }
 
 /**
- * Removes all whitespace that does not exist between 2 adjacent word boundaries,
- * and makes all remaining whitespace single spaced.
+ * Removes all whitespace except for whitespace that exists between 2 adjacent word boundaries,
+ * and normalizes that whitespace to be single spaces.
  */
 export function normalize(text: string): string {
     return text.replace(/\b\s+\B|\B\s+\b|\B\s+\B/g, '').replace(/\s+/g, ' ');

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -58,7 +58,7 @@ export function compareDirectoryPaths(directoryPath_a: string, directoryPath_b: 
     return a_segments.length !== b_segments.length ? coefficient + 1 : coefficient;
 }
 
-export function arraysAreEqual<T>(array_a: T[], array_b: T[]): boolean {
+export function arraysAreEqual<T>(array_a: ReadonlyArray<T>, array_b: ReadonlyArray<T>): boolean {
     if (array_a.length !== array_b.length) {
         return false;
     }
@@ -75,7 +75,7 @@ export function arraysAreEqual<T>(array_a: T[], array_b: T[]): boolean {
  * the other, starting from the beginning of the arrays.
  * For example, [1, 2, 3] and [1, 2] intersect while [1, 2, 3] and [2, 3] do not.
  */
-export function arraysIntersect<T>(array_a: T[], array_b: T[]): boolean {
+export function arraysIntersect<T>(array_a: ReadonlyArray<T>, array_b: ReadonlyArray<T>): boolean {
     const minLength = Math.min(array_a.length, array_b.length);
     for (let i = 0; i < minLength; ++i) {
         if (array_a[i] !== array_b[i]) {
@@ -85,7 +85,7 @@ export function arraysIntersect<T>(array_a: T[], array_b: T[]): boolean {
     return true;
 }
 
-export function arraysShareAnyElement<T>(array_a: T[], array_b: T[]): boolean {
+export function arraysShareAnyElement<T>(array_a: ReadonlyArray<T>, array_b: ReadonlyArray<T>): boolean {
     for (const element of array_a) {
         if (array_b.includes(element)) {
             return true;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -58,27 +58,37 @@ export function compareDirectoryPaths(directoryPath_a: string, directoryPath_b: 
     return a_segments.length !== b_segments.length ? coefficient + 1 : coefficient;
 }
 
-export function arraysAreEqual<T>(array_a: ReadonlyArray<T>, array_b: ReadonlyArray<T>): boolean {
+export function arraysAreEqual<T>(
+    array_a: ReadonlyArray<T>,
+    array_b: ReadonlyArray<T>,
+    equalityFn: (a: T, b: T) => boolean = (a: T, b: T) => a === b
+): boolean {
     if (array_a.length !== array_b.length) {
         return false;
     }
+
     for (let i = 0; i < array_a.length; ++i) {
-        if (array_a[i] !== array_b[i]) {
+        if (!equalityFn(array_a[i], array_b[i])) {
             return false;
         }
     }
+
     return true;
 }
 
 /**
  * Returns true if the arrays are equal, or if either array is a sub-array of
  * the other, starting from the beginning of the arrays.
- * For example, [1, 2, 3] and [1, 2] intersect while [1, 2, 3] and [2, 3] do not.
+ * For example, `[1,2,3]` and `[1,2]` intersect while `[1,2,3]` and `[2,3]` do not.
  */
-export function arraysIntersect<T>(array_a: ReadonlyArray<T>, array_b: ReadonlyArray<T>): boolean {
+export function arraysIntersect<T>(
+    array_a: ReadonlyArray<T>,
+    array_b: ReadonlyArray<T>,
+    equalityFn: (a: T, b: T) => boolean = (a: T, b: T) => a === b
+): boolean {
     const minLength = Math.min(array_a.length, array_b.length);
     for (let i = 0; i < minLength; ++i) {
-        if (array_a[i] !== array_b[i]) {
+        if (!equalityFn(array_a[i], array_b[i])) {
             return false;
         }
     }


### PR DESCRIPTION
This feature adds a code-action to synchronize a function's signature between it's declaration and definition. After changing a function's signature, the light-bulb will pop up to prompt you to update the declaration/definition of the function (if that function had a matching declaration/definition). This feature automatically detects changes to function signatures as you type, which makes editing feel natural as there is no need to indicate beforehand that you want to change a function's signature.