### PR TITLE
Fix double lines in CRLF EOL endings

### DIFF
--- a/src/ProposedPosition.ts
+++ b/src/ProposedPosition.ts
@@ -47,7 +47,7 @@ function formatTextToInsert(
     insertText: string, position: ProposedPosition, sourceDoc: SourceDocument
 ): string {
     if (position.options.indent) {
-        insertText = insertText.replace(/^/gm, util.indentation());
+        insertText = util.insertBeforeEachLine(insertText, util.indentation()); // insertText.replace(/^/gm, util.indentation());
     }
 
     // Indent text to match the relative position.
@@ -56,7 +56,7 @@ function formatTextToInsert(
             : sourceDoc.lineAt(position);
     const indentation = indentationLine.text.substring(0, indentationLine.firstNonWhitespaceCharacterIndex);
     if (!position.options.before) {
-        insertText = insertText.replace(/^/gm, indentation);
+        insertText = util.insertBeforeEachLine(insertText, indentation); // insertText.replace(/^/gm, indentation);
     } else {
         insertText = insertText.replace(/\n/gm, '\n' + indentation);
     }

--- a/src/commands/createSourceFile.ts
+++ b/src/commands/createSourceFile.ts
@@ -193,7 +193,7 @@ function generateNamespaces(namespaces: CSymbol[], eol: string): string {
                 if (body) {
                     if (childNamespaces.length > 0
                             && childNamespaces[0].trueStart.character > namespace.trueStart.character) {
-                        namespaceText += body.replace(/^/gm, indentation);
+                        namespaceText += util.insertBeforeEachLine(body, indentation); // body.replace(/^/gm, indentation);
                     } else {
                         namespaceText += body;
                     }

--- a/src/commands/createSourceFile.ts
+++ b/src/commands/createSourceFile.ts
@@ -204,7 +204,7 @@ function generateNamespaces(namespaces: CSymbol[], eol: string): string {
             }
         }
         return namespaceText;
-    } (namespaces).replace(/\s+$/gm, eol);
+    } (namespaces).replace(/[^\S\r\n]+\n/g, eol);
 }
 
 function getNamespaceCurlySeparator(namespaces: CSymbol[], eol: string): string {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -149,6 +149,11 @@ export function indentation(options?: vscode.TextEditorOptions): string {
     return '\t';
 }
 
+export function insertBeforeEachLine(text: string, indentation: string): string {
+    text = text.replace(/\n/gm, '\n' + indentation);
+    return indentation + text;
+}
+
 export function lineCount(text: string): number {
     return (text.endsWith('\n')) ? text.split('\n').length - 1 : text.split('\n').length;
 }


### PR DESCRIPTION
I noticed a strange bug when using CRLF line endings.
Whenever i wanted to add a definition, somehow an excess of newlines would appear, e.g.:

```cpp
	void Instance::function()

	{



	}
```

Which seemed strange, at first and after a little digging, I found the issue:

Whenever you add tabspaces to a block, you appear to use `insertText.replace(/^/gm, util.indentation())` to prepend any indentation. Unfortunatly it does work only with LF line endings. When using CRLF line endings, it assumes the `\r` and `\n` are both line seperators (instead of completly`\r\n`), which led to inserting tabspaces between and after them, resulting in `\r\t\n\t`. Then, vscode would translate these into `\r\n\t\r\n\t` (or at least in an equivalent visual representation).
To fix the issue, I have created a function in `utilities`, called `insertBeforeEachLine`, which solves the issue and I have replaced each occurence `$1.replace(/^/gm, $2)` with `util.insertBeforeEachLine($1, $2)`.